### PR TITLE
Change the way how to pay about >1024 transaction. (2x)

### DIFF
--- a/SimplePolicy.UnitTests/UT_SimplePolicy.cs
+++ b/SimplePolicy.UnitTests/UT_SimplePolicy.cs
@@ -291,87 +291,87 @@ namespace SimplePolicy.UnitTests
         }
 
          [TestMethod]
-        public void TestVerifySizeLimits_FreeLessEq1024()
+        public void TestVerifySizeLimits1_FreeLessEq1024()
         {
-            var txLowPriority = MockGenerateInvocationTransaction(new Fixed8(100000000 / 10000), 1024).Object; // 0.00001
+            var txLowPriority = MockGenerateInvocationTransaction(new Fixed8(100000000 / 10000), 1024).Object; // 0.0001
             txLowPriority.IsLowPriority.Should().Be(true);
             txLowPriority.Size.Should().Be(1024); 
             Settings.Default.MaxFreeTransactionSize.Should().Be(1024);
             
-            uut.VerifySizeLimits(txLowPriority).Should().Be(true); // 1024 <= 1024
+            uut.VerifySizeLimits1(txLowPriority).Should().Be(true); // 1024 <= 1024
         }
 
 
         [TestMethod]
-        public void TestVerifySizeLimits_FreeGreater1024()
+        public void TestVerifySizeLimits1_FreeGreater1024()
         {
-            var txLowPriority = MockGenerateInvocationTransaction(new Fixed8(100000000 / 10000), 1025).Object; // 0.00001
+            var txLowPriority = MockGenerateInvocationTransaction(new Fixed8(100000000 / 10000), 1025).Object; // 0.0001
             txLowPriority.IsLowPriority.Should().Be(true);
             txLowPriority.Size.Should().Be(1025); 
             Settings.Default.MaxFreeTransactionSize.Should().Be(1024);
             
-            uut.VerifySizeLimits(txLowPriority).Should().Be(false); // 1025 > 1024
+            uut.VerifySizeLimits1(txLowPriority).Should().Be(false); // 1025 > 1024
         }
 
 
         [TestMethod]
-        public void TestVerifySizeLimits_HighPriorityLessEq1024()
+        public void TestVerifySizeLimits1_HighPriorityLessEq1024()
         {
-            var txHighPriority = MockGenerateInvocationTransaction(new Fixed8(100000000 / 1000), 1024).Object; // 0.0001
+            var txHighPriority = MockGenerateInvocationTransaction(new Fixed8(100000000 / 1000), 1024).Object; // 0.001
             txHighPriority.IsLowPriority.Should().Be(false);
             txHighPriority.Size.Should().Be(1024); 
             Settings.Default.MaxFreeTransactionSize.Should().Be(1024);
             
-            uut.VerifySizeLimits(txHighPriority).Should().Be(true); // 1024 <= 1024
+            uut.VerifySizeLimits1(txHighPriority).Should().Be(true); // 1024 <= 1024
         }
 
 
         [TestMethod]
-        public void TestVerifySizeLimits_HighPriorityGreater1024_1025()
+        public void TestVerifySizeLimits1_HighPriorityGreater1024_1025()
         {
-            var txHighPriority = MockGenerateInvocationTransaction(new Fixed8(100000000 / 1000), 1025).Object; // 0.0001
+            var txHighPriority = MockGenerateInvocationTransaction(new Fixed8(100000000 / 1000), 1025).Object; // 0.001
             txHighPriority.IsLowPriority.Should().Be(false);
             txHighPriority.Size.Should().Be(1025); 
             Settings.Default.MaxFreeTransactionSize.Should().Be(1024);
-            Settings.Default.FeePerExtraByte.Should().Be(new Fixed8(100000000 / 100000)); // 0.000001 (1000 satoshi)
+            Settings.Default.FeePerExtraByte.Should().Be(new Fixed8(100000000 / 100000)); // 0.00001 (1000 satoshi)
             
-            uut.VerifySizeLimits(txHighPriority).Should().Be(true); // 1025 > 1024 (extra fee was 1 byte * 1000 satoshi = 0.000001)
+            uut.VerifySizeLimits1(txHighPriority).Should().Be(true); // 1025 > 1024 (extra fee was 1 byte * 1000 satoshi = 0.00001)
         }
 
         [TestMethod]
-        public void TestVerifySizeLimits_HighPriorityGreater1024_1124()
+        public void TestVerifySizeLimits1_HighPriorityGreater1024_1124()
         {
-            var txHighPriority = MockGenerateInvocationTransaction(new Fixed8(100000000 / 1000), 1124).Object; // 0.0001
+            var txHighPriority = MockGenerateInvocationTransaction(new Fixed8(100000000 / 1000), 1124).Object; // 0.001
             txHighPriority.IsLowPriority.Should().Be(false);
             txHighPriority.Size.Should().Be(1124); 
             Settings.Default.MaxFreeTransactionSize.Should().Be(1024);
-            Settings.Default.FeePerExtraByte.Should().Be(new Fixed8(100000000 / 100000)); // 0.000001 (1000 satoshi)
+            Settings.Default.FeePerExtraByte.Should().Be(new Fixed8(100000000 / 100000)); // 0.00001 (1000 satoshi)
             
-            uut.VerifySizeLimits(txHighPriority).Should().Be(true); // 1124 > 1024 (extra fee was 100 byte * 1000 satoshi = 0.0001)
+            uut.VerifySizeLimits1(txHighPriority).Should().Be(true); // 1124 > 1024 (extra fee was 100 byte * 1000 satoshi = 0.0001)
         }
 
          [TestMethod]
-        public void TestVerifySizeLimits_HighPriorityGreater1024_1125_unpaid_fails()
+        public void TestVerifySizeLimits1_HighPriorityGreater1024_1125_unpaid_fails()
         {
-            var txHighPriority = MockGenerateInvocationTransaction(new Fixed8(100000000 / 1000), 1125).Object; // 0.0001
+            var txHighPriority = MockGenerateInvocationTransaction(new Fixed8(100000000 / 1000), 1125).Object; // 0.001
             txHighPriority.IsLowPriority.Should().Be(false);
             txHighPriority.Size.Should().Be(1125); 
             Settings.Default.MaxFreeTransactionSize.Should().Be(1024);
-            Settings.Default.FeePerExtraByte.Should().Be(new Fixed8(100000000 / 100000)); // 0.000001 (1000 satoshi)
+            Settings.Default.FeePerExtraByte.Should().Be(new Fixed8(100000000 / 100000)); // 0.00001 (1000 satoshi)
             // should fail because of 1000 unpaid satoshi... (1 byte over)
-            uut.VerifySizeLimits(txHighPriority).Should().Be(false); // 1125 > 1024 (extra fee was 101 byte * 1000 satoshi = 0.0001001)
+            uut.VerifySizeLimits1(txHighPriority).Should().Be(false); // 1125 > 1024 (extra fee was 101 byte * 1000 satoshi = 0.00101)
         }
 
                  [TestMethod]
-        public void TestVerifySizeLimits_HighPriorityGreater1024_1125_paid_NotFail()
+        public void TestVerifySizeLimits1_HighPriorityGreater1024_1125_paid_NotFail()
         {
-            var txHighPriority = MockGenerateInvocationTransaction(new Fixed8(100000000 / 1000 + 1000), 1125).Object; // 0.000101
+            var txHighPriority = MockGenerateInvocationTransaction(new Fixed8(100000000 / 1000 + 1000), 1125).Object; // 0.00101
             txHighPriority.IsLowPriority.Should().Be(false);
             txHighPriority.Size.Should().Be(1125); 
             Settings.Default.MaxFreeTransactionSize.Should().Be(1024);
-            Settings.Default.FeePerExtraByte.Should().Be(new Fixed8(100000000 / 100000)); // 0.000001 (1000 satoshi)
-            // should pass (total charged is 0.000101)
-            uut.VerifySizeLimits(txHighPriority).Should().Be(true); // 1125 > 1024 (extra fee was 101 byte * 1000 satoshi = 0.000101)
+            Settings.Default.FeePerExtraByte.Should().Be(new Fixed8(100000000 / 100000)); // 0.00001 (1000 satoshi)
+            // should pass (total charged is 0.00101)
+            uut.VerifySizeLimits1(txHighPriority).Should().Be(true); // 1125 > 1024 (extra fee was 101 byte * 1000 satoshi = 0.00101)
         }
 
         // Generate Mock InvocationTransaction with different sizes and prices

--- a/SimplePolicy/Settings.cs
+++ b/SimplePolicy/Settings.cs
@@ -12,7 +12,8 @@ namespace Neo.Plugins
         public int MaxTransactionsPerBlock { get; }
         public int MaxFreeTransactionsPerBlock { get; }
         public int MaxFreeTransactionSize { get; }
-        public Fixed8 FeePerExtraByte { get; }
+        public Fixed8 FeePerExtraBlock { get; }
+        public int ExtraBlockSize { get; }
         public EnumSet<TransactionType> HighPriorityTxType { get; }
         public BlockedAccounts BlockedAccounts { get; }
 
@@ -23,7 +24,8 @@ namespace Neo.Plugins
             this.MaxTransactionsPerBlock = GetValueOrDefault(section.GetSection("MaxTransactionsPerBlock"), 500, p => int.Parse(p));
             this.MaxFreeTransactionsPerBlock = GetValueOrDefault(section.GetSection("MaxFreeTransactionsPerBlock"), 20, p => int.Parse(p));
             this.MaxFreeTransactionSize = GetValueOrDefault(section.GetSection("MaxFreeTransactionSize"), 1024, p => int.Parse(p));
-            this.FeePerExtraByte = GetValueOrDefault(section.GetSection("FeePerExtraByte"), Fixed8.FromDecimal(0.00001M), p => Fixed8.Parse(p));
+            this.FeePerExtraBlock = GetValueOrDefault(section.GetSection("FeePerExtraByte"), Fixed8.FromDecimal(0.01024M), p => Fixed8.Parse(p));
+            this.ExtraBlockSize = GetValueOrDefault(section.GetSection("ExtraBlockSize"), 1024, p => int.Parse(p));
             this.HighPriorityTxType = new EnumSet<TransactionType>(section.GetSection("HighPriorityTxType"), TransactionType.ClaimTransaction);
             this.BlockedAccounts = new BlockedAccounts(section.GetSection("BlockedAccounts"));
         }

--- a/SimplePolicy/Settings.cs
+++ b/SimplePolicy/Settings.cs
@@ -12,6 +12,7 @@ namespace Neo.Plugins
         public int MaxTransactionsPerBlock { get; }
         public int MaxFreeTransactionsPerBlock { get; }
         public int MaxFreeTransactionSize { get; }
+        public Fixed8 FeePerExtraByte { get; }
         public Fixed8 FeePerExtraBlock { get; }
         public int ExtraBlockSize { get; }
         public EnumSet<TransactionType> HighPriorityTxType { get; }
@@ -24,6 +25,7 @@ namespace Neo.Plugins
             this.MaxTransactionsPerBlock = GetValueOrDefault(section.GetSection("MaxTransactionsPerBlock"), 500, p => int.Parse(p));
             this.MaxFreeTransactionsPerBlock = GetValueOrDefault(section.GetSection("MaxFreeTransactionsPerBlock"), 20, p => int.Parse(p));
             this.MaxFreeTransactionSize = GetValueOrDefault(section.GetSection("MaxFreeTransactionSize"), 1024, p => int.Parse(p));
+            this.FeePerExtraByte = GetValueOrDefault(section.GetSection("FeePerExtraByte"), Fixed8.FromDecimal(0.00001M), p => Fixed8.Parse(p));
             this.FeePerExtraBlock = GetValueOrDefault(section.GetSection("FeePerExtraByte"), Fixed8.FromDecimal(0.01024M), p => Fixed8.Parse(p));
             this.ExtraBlockSize = GetValueOrDefault(section.GetSection("ExtraBlockSize"), 1024, p => int.Parse(p));
             this.HighPriorityTxType = new EnumSet<TransactionType>(section.GetSection("HighPriorityTxType"), TransactionType.ClaimTransaction);

--- a/SimplePolicy/SimplePolicy/config.json
+++ b/SimplePolicy/SimplePolicy/config.json
@@ -2,6 +2,7 @@
   "PluginConfiguration": {
     "MaxTransactionsPerBlock": 500,
     "MaxFreeTransactionsPerBlock": 20,
+    "FeePerExtraByte": 0.00001,
     "MaxFreeTransactionSize": 1024,
     "FeePerExtraBlock": 0.01024,
     "ExtraBlockSize": 1024,

--- a/SimplePolicy/SimplePolicy/config.json
+++ b/SimplePolicy/SimplePolicy/config.json
@@ -3,7 +3,8 @@
     "MaxTransactionsPerBlock": 500,
     "MaxFreeTransactionsPerBlock": 20,
     "MaxFreeTransactionSize": 1024,
-    "FeePerExtraByte": 0.00001,
+    "FeePerExtraBlock": 0.01024,
+    "ExtraBlockSize": 1024,
     "HighPriorityTxType":
     [
         "ClaimTransaction"

--- a/SimplePolicy/SimplePolicyPlugin.cs
+++ b/SimplePolicy/SimplePolicyPlugin.cs
@@ -98,6 +98,30 @@ namespace Neo.Plugins
 
         internal protected bool VerifySizeLimits(Transaction tx)
         {
+            return VerifySizeLimits2(tx); // fee per block
+        }
+
+        // fee per byte
+        internal protected bool VerifySizeLimits1(Transaction tx)
+        {
+            if (InHigherLowPriorityList(tx)) return true;
+
+            // Not Allow free TX bigger than MaxFreeTransactionSize
+            if (tx.IsLowPriority && tx.Size > Settings.Default.MaxFreeTransactionSize) return false;
+
+            // Require proportional fee for TX bigger than MaxFreeTransactionSize
+            if (tx.Size > Settings.Default.MaxFreeTransactionSize)
+            {
+                Fixed8 fee = Settings.Default.FeePerExtraByte * (tx.Size - Settings.Default.MaxFreeTransactionSize);
+
+                if (tx.NetworkFee < fee) return false;
+            }
+            return true;
+        }
+
+        // fee per block
+        internal protected bool VerifySizeLimits2(Transaction tx)
+        {
             if (InHigherLowPriorityList(tx)) return true;
 
             // Not Allow free TX bigger than MaxFreeTransactionSize

--- a/SimplePolicy/SimplePolicyPlugin.cs
+++ b/SimplePolicy/SimplePolicyPlugin.cs
@@ -106,7 +106,12 @@ namespace Neo.Plugins
             // Require proportional fee for TX bigger than MaxFreeTransactionSize
             if (tx.Size > Settings.Default.MaxFreeTransactionSize)
             {
-                Fixed8 fee = Settings.Default.FeePerExtraByte * (tx.Size - Settings.Default.MaxFreeTransactionSize);
+                decimal payBytes = (tx.Size - Settings.Default.MaxFreeTransactionSize);
+                //when extrablocksize==1 ，pay per bytes
+                //when extrablocksize==1024 ，pay per 1k bytes
+                long payBlockCount =(long) Math.Ceiling(payBytes / Settings.Default.ExtraBlockSize);
+
+                Fixed8 fee = Settings.Default.FeePerExtraBlock * payBlockCount;
 
                 if (tx.NetworkFee < fee) return false;
             }


### PR DESCRIPTION
#neo-project/neo-cli#303

pay for every extrablock instread  every bytes

in default extrablock=1024 bytes.
feeperextrablock=0.0124.gas


example:
txsize  < 1024, pay 0 block,free
txsize =1025  ~  2048 bytes, pay 1 block    0.01024gas
txsize =2049  ~  3072 bytes, pay 2 block    0.02048gas

if you want pay by every extrabytes
set extrablock=1 bytes
feeperextrablock =0.0001gas
