### PR TITLE
Enable programmatic configuration of RpcServer plugin

### DIFF
--- a/src/ApplicationLogs/LogReader.cs
+++ b/src/ApplicationLogs/LogReader.cs
@@ -21,7 +21,7 @@ namespace Neo.Plugins
         public LogReader()
         {
             db = DB.Open(GetFullPath(Settings.Default.Path), new Options { CreateIfMissing = true });
-            RpcServer.RegisterMethods(this);
+            RpcServerPlugin.RegisterMethods(this);
         }
 
         protected override void Configure()

--- a/src/RpcNep5Tracker/RpcNep5Tracker.cs
+++ b/src/RpcNep5Tracker/RpcNep5Tracker.cs
@@ -35,7 +35,7 @@ namespace Neo.Plugins
 
         public RpcNep5Tracker()
         {
-            RpcServer.RegisterMethods(this);
+            RpcServerPlugin.RegisterMethods(this);
         }
 
         protected override void Configure()

--- a/src/RpcServer/RpcServer.Node.cs
+++ b/src/RpcServer/RpcServer.Node.cs
@@ -70,7 +70,7 @@ namespace Neo.Plugins
         private JObject SendRawTransaction(JArray _params)
         {
             Transaction tx = _params[0].AsString().HexToBytes().AsSerializable<Transaction>();
-            RelayResultReason reason = System.Blockchain.Ask<RelayResultReason>(tx).Result;
+            RelayResultReason reason = system.Blockchain.Ask<RelayResultReason>(tx).Result;
             return GetRelayResult(reason, tx.Hash);
         }
 
@@ -78,7 +78,7 @@ namespace Neo.Plugins
         private JObject SubmitBlock(JArray _params)
         {
             Block block = _params[0].AsString().HexToBytes().AsSerializable<Block>();
-            RelayResultReason reason = System.Blockchain.Ask<RelayResultReason>(block).Result;
+            RelayResultReason reason = system.Blockchain.Ask<RelayResultReason>(block).Result;
             return GetRelayResult(reason, block.Hash);
         }
     }

--- a/src/RpcServer/RpcServer.Node.cs
+++ b/src/RpcServer/RpcServer.Node.cs
@@ -71,7 +71,7 @@ namespace Neo.Plugins
         private JObject SendRawTransaction(JArray _params)
         {
             Transaction tx = _params[0].AsString().HexToBytes().AsSerializable<Transaction>();
-            RelayResult reason = System.Blockchain.Ask<RelayResult>(tx).Result;
+            RelayResult reason = system.Blockchain.Ask<RelayResult>(tx).Result;
             return GetRelayResult(reason.Result, tx.Hash);
         }
 
@@ -79,7 +79,7 @@ namespace Neo.Plugins
         private JObject SubmitBlock(JArray _params)
         {
             Block block = _params[0].AsString().HexToBytes().AsSerializable<Block>();
-            RelayResult reason = System.Blockchain.Ask<RelayResult>(block).Result;
+            RelayResult reason = system.Blockchain.Ask<RelayResult>(block).Result;
             return GetRelayResult(reason.Result, block.Hash);
         }
     }

--- a/src/RpcServer/RpcServer.SmartContract.cs
+++ b/src/RpcServer/RpcServer.SmartContract.cs
@@ -53,7 +53,7 @@ namespace Neo.Plugins
 
         private JObject GetInvokeResult(byte[] script, IVerifiable checkWitnessHashes = null)
         {
-            using ApplicationEngine engine = ApplicationEngine.Run(script, checkWitnessHashes, extraGAS: Settings.Default.MaxGasInvoke);
+            using ApplicationEngine engine = ApplicationEngine.Run(script, checkWitnessHashes, extraGAS: settings.MaxGasInvoke);
             JObject json = new JObject();
             json["script"] = script.ToHexString();
             json["state"] = engine.State;

--- a/src/RpcServer/RpcServer.Utilities.cs
+++ b/src/RpcServer/RpcServer.Utilities.cs
@@ -12,7 +12,7 @@ namespace Neo.Plugins
         [RpcMethod]
         private JObject ListPlugins(JArray _params)
         {
-            return new JArray(Plugins
+            return new JArray(Neo.Plugins.Plugin.Plugins
                 .OrderBy(u => u.Name)
                 .Select(u => new JObject
                 {

--- a/src/RpcServer/RpcServer.Wallet.cs
+++ b/src/RpcServer/RpcServer.Wallet.cs
@@ -187,7 +187,7 @@ namespace Neo.Plugins
                 if (tx.NetworkFee < calFee)
                     tx.NetworkFee = calFee;
             }
-            if (tx.NetworkFee > Settings.Default.MaxFee)
+            if (tx.NetworkFee > settings.MaxFee)
                 throw new RpcException(-301, "The necessary fee is more than the Max_fee, this transaction is failed. Please increase your Max_fee value.");
             return SignAndRelay(tx);
         }
@@ -235,7 +235,7 @@ namespace Neo.Plugins
                 if (tx.NetworkFee < calFee)
                     tx.NetworkFee = calFee;
             }
-            if (tx.NetworkFee > Settings.Default.MaxFee)
+            if (tx.NetworkFee > settings.MaxFee)
                 throw new RpcException(-301, "The necessary fee is more than the Max_fee, this transaction is failed. Please increase your Max_fee value.");
             return SignAndRelay(tx);
         }
@@ -273,7 +273,7 @@ namespace Neo.Plugins
                 if (tx.NetworkFee < calFee)
                     tx.NetworkFee = calFee;
             }
-            if (tx.NetworkFee > Settings.Default.MaxFee)
+            if (tx.NetworkFee > settings.MaxFee)
                 throw new RpcException(-301, "The necessary fee is more than the Max_fee, this transaction is failed. Please increase your Max_fee value.");
             return SignAndRelay(tx);
         }
@@ -285,7 +285,7 @@ namespace Neo.Plugins
             if (context.Completed)
             {
                 tx.Witnesses = context.GetWitnesses();
-                System.LocalNode.Tell(new LocalNode.Relay { Inventory = tx });
+                system.LocalNode.Tell(new LocalNode.Relay { Inventory = tx });
                 return tx.ToJson();
             }
             else

--- a/src/RpcServer/RpcServer.cs
+++ b/src/RpcServer/RpcServer.cs
@@ -86,7 +86,7 @@ namespace Neo.Plugins
             }
         }
 
-        public void StartHost()
+        public void StartRpcServer()
         {
             host = new WebHostBuilder().UseKestrel(options => options.Listen(settings.BindAddress, settings.Port, listenOptions =>
             {

--- a/src/RpcServer/RpcServer.cs
+++ b/src/RpcServer/RpcServer.cs
@@ -77,7 +77,7 @@ namespace Neo.Plugins
             return response;
         }
 
-        public  void Dispose()
+        public void Dispose()
         {
             if (host != null)
             {

--- a/src/RpcServer/RpcServer.cs
+++ b/src/RpcServer/RpcServer.cs
@@ -19,19 +19,24 @@ using System.Threading.Tasks;
 
 namespace Neo.Plugins
 {
-    public sealed partial class RpcServer : Plugin
+    public sealed partial class RpcServer : IDisposable
     {
-        private static readonly Dictionary<string, Func<JArray, JObject>> methods = new Dictionary<string, Func<JArray, JObject>>();
-        private IWebHost host;
+        private readonly Dictionary<string, Func<JArray, JObject>> methods = new Dictionary<string, Func<JArray, JObject>>();
 
-        public RpcServer()
+        private IWebHost host;
+        private readonly RpcServerSettings settings;
+        private readonly NeoSystem system;
+
+        public RpcServer(NeoSystem system, RpcServerSettings settings)
         {
+            this.system = system;
+            this.settings = settings;
             RegisterMethods(this);
         }
 
         private bool CheckAuth(HttpContext context)
         {
-            if (string.IsNullOrEmpty(Settings.Default.RpcUser)) return true;
+            if (string.IsNullOrEmpty(settings.RpcUser)) return true;
 
             context.Response.Headers["WWW-Authenticate"] = "Basic realm=\"Restricted\"";
 
@@ -50,12 +55,7 @@ namespace Neo.Plugins
             if (authvalues.Length < 2)
                 return false;
 
-            return authvalues[0] == Settings.Default.RpcUser && authvalues[1] == Settings.Default.RpcPass;
-        }
-
-        protected override void Configure()
-        {
-            Settings.Load(GetConfiguration());
+            return authvalues[0] == settings.RpcUser && authvalues[1] == settings.RpcPass;
         }
 
         private static JObject CreateErrorResponse(JObject id, int code, string message, JObject data = null)
@@ -77,9 +77,8 @@ namespace Neo.Plugins
             return response;
         }
 
-        public override void Dispose()
+        public  void Dispose()
         {
-            base.Dispose();
             if (host != null)
             {
                 host.Dispose();
@@ -87,21 +86,21 @@ namespace Neo.Plugins
             }
         }
 
-        protected override void OnPluginsLoaded()
+        public void StartHost()
         {
-            host = new WebHostBuilder().UseKestrel(options => options.Listen(Settings.Default.BindAddress, Settings.Default.Port, listenOptions =>
+            host = new WebHostBuilder().UseKestrel(options => options.Listen(settings.BindAddress, settings.Port, listenOptions =>
             {
                 // Default value is unlimited
-                options.Limits.MaxConcurrentConnections = Settings.Default.MaxConcurrentConnections;
+                options.Limits.MaxConcurrentConnections = settings.MaxConcurrentConnections;
                 // Default value is 2 minutes
                 options.Limits.KeepAliveTimeout = TimeSpan.FromMinutes(1);
                 // Default value is 30 seconds
                 options.Limits.RequestHeadersTimeout = TimeSpan.FromSeconds(15);
 
-                if (string.IsNullOrEmpty(Settings.Default.SslCert)) return;
-                listenOptions.UseHttps(Settings.Default.SslCert, Settings.Default.SslCertPassword, httpsConnectionAdapterOptions =>
+                if (string.IsNullOrEmpty(settings.SslCert)) return;
+                listenOptions.UseHttps(settings.SslCert, settings.SslCertPassword, httpsConnectionAdapterOptions =>
                 {
-                    if (Settings.Default.TrustedAuthorities is null || Settings.Default.TrustedAuthorities.Length == 0)
+                    if (settings.TrustedAuthorities is null || settings.TrustedAuthorities.Length == 0)
                         return;
                     httpsConnectionAdapterOptions.ClientCertificateMode = ClientCertificateMode.RequireCertificate;
                     httpsConnectionAdapterOptions.ClientCertificateValidation = (cert, chain, err) =>
@@ -109,7 +108,7 @@ namespace Neo.Plugins
                         if (err != SslPolicyErrors.None)
                             return false;
                         X509Certificate2 authority = chain.ChainElements[chain.ChainElements.Count - 1].Certificate;
-                        return Settings.Default.TrustedAuthorities.Contains(authority.Thumbprint);
+                        return settings.TrustedAuthorities.Contains(authority.Thumbprint);
                     };
                 });
             }))
@@ -211,7 +210,7 @@ namespace Neo.Plugins
             try
             {
                 string method = request["method"].AsString();
-                if (!CheckAuth(context) || Settings.Default.DisabledMethods.Contains(method))
+                if (!CheckAuth(context) || settings.DisabledMethods.Contains(method))
                     throw new RpcException(-400, "Access denied");
                 if (!methods.TryGetValue(method, out var func))
                     throw new RpcException(-32601, "Method not found");
@@ -236,7 +235,7 @@ namespace Neo.Plugins
             }
         }
 
-        public static void RegisterMethods(object handler)
+        public void RegisterMethods(object handler)
         {
             foreach (MethodInfo method in handler.GetType().GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
             {

--- a/src/RpcServer/RpcServerPlugin.cs
+++ b/src/RpcServer/RpcServerPlugin.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+
+namespace Neo.Plugins
+{
+    public sealed class RpcServerPlugin : Plugin
+    {
+        static List<object> handlers = new List<object>();
+        RpcServer server;
+        RpcServerSettings settings;
+
+        protected override void Configure()
+        {
+            settings = new RpcServerSettings(GetConfiguration());
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            if (server != null)
+            {
+                server.Dispose();
+                server = null;
+            }
+        }
+
+        protected override void OnPluginsLoaded()
+        {
+            this.server = new RpcServer(System, settings);
+
+            foreach (var handler in handlers)
+            {
+                this.server.RegisterMethods(handler);
+            }
+            handlers.Clear();
+
+            server.StartHost();
+        }
+
+        public static void RegisterMethods(object handler)
+        {
+            // if RpcServerPlugin is already loaded, call RegisterMethods directly
+            foreach (var plugin in Plugin.Plugins)
+            {
+                if (plugin is RpcServerPlugin rpcServerPlugin)
+                {
+                    rpcServerPlugin.server.RegisterMethods(handler);
+                    return;
+                }
+            }
+
+            // otherwise, save the handler for use during RpcServerPlugin load
+            handlers.Add(handler);
+        }
+    }
+}

--- a/src/RpcServer/RpcServerPlugin.cs
+++ b/src/RpcServer/RpcServerPlugin.cs
@@ -10,7 +10,15 @@ namespace Neo.Plugins
 
         protected override void Configure()
         {
-            settings = new RpcServerSettings(GetConfiguration());
+            var loadedSettings = new RpcServerSettings(GetConfiguration());
+            if (this.settings == null)
+            {
+                this.settings = loadedSettings;
+            }
+            else
+            {
+                this.settings.UpdateSettings(loadedSettings);
+            }
         }
 
         public override void Dispose()
@@ -33,7 +41,7 @@ namespace Neo.Plugins
             }
             handlers.Clear();
 
-            server.StartHost();
+            server.StartRpcServer();
         }
 
         public static void RegisterMethods(object handler)

--- a/src/RpcServer/RpcServerSettings.cs
+++ b/src/RpcServer/RpcServerSettings.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration;
 using Neo.SmartContract.Native;
 using System;
 using System.Linq;

--- a/src/RpcServer/RpcServerSettings.cs
+++ b/src/RpcServer/RpcServerSettings.cs
@@ -3,22 +3,31 @@ using Neo.SmartContract.Native;
 using System;
 using System.Linq;
 using System.Net;
+using System.Numerics;
 
 namespace Neo.Plugins
 {
     public class RpcServerSettings
     {
+        // These read-only properties are used to in the creation
+        // of the WebHost RPC endpoint. These cannot be changed
+        // while the server is running
+
         public IPAddress BindAddress { get; }
         public ushort Port { get; }
         public string SslCert { get; }
         public string SslCertPassword { get; }
         public string[] TrustedAuthorities { get; }
-        public string RpcUser { get; }
-        public string RpcPass { get; }
-        public long MaxGasInvoke { get; }
-        public long MaxFee { get; }
-        public string[] DisabledMethods { get; }
         public int MaxConcurrentConnections { get; }
+
+        // these read-write properties can be changed while
+        // the server is running via auto-reconfiguration
+
+        public string RpcUser { get; private set; }
+        public string RpcPass { get; private set; }
+        public long MaxGasInvoke { get; private set; }
+        public long MaxFee { get; private set; }
+        public string[] DisabledMethods { get; private set; }
 
         public RpcServerSettings(IPAddress bindAddress = null,
             ushort port = 10332,
@@ -27,8 +36,8 @@ namespace Neo.Plugins
             string[] trustedAuthorities = null,
             string rpcUser = "",
             string rpcPass = "",
-            string masGasInvoke = "10",
-            string maxFee = "0.1",
+            decimal maxGasInvoke = 10,
+            decimal maxFee = (decimal)0.1,
             string[] disabledMethods = null,
             int maxConcurrentConnections = 40)
         {
@@ -39,8 +48,8 @@ namespace Neo.Plugins
             this.TrustedAuthorities = trustedAuthorities ?? Array.Empty<string>();
             this.RpcUser = rpcUser;
             this.RpcPass = rpcPass;
-            this.MaxGasInvoke = (long)BigDecimal.Parse(masGasInvoke, NativeContract.GAS.Decimals).Value;
-            this.MaxFee = (long)BigDecimal.Parse(maxFee, NativeContract.GAS.Decimals).Value;
+            this.MaxGasInvoke = (long)BigDecimal.Parse(maxGasInvoke.ToString(), NativeContract.GAS.Decimals).Value;
+            this.MaxFee = (long)BigDecimal.Parse(maxFee.ToString(), NativeContract.GAS.Decimals).Value;
             this.DisabledMethods = disabledMethods ?? Array.Empty<string>();
             this.MaxConcurrentConnections = maxConcurrentConnections;
         }
@@ -58,6 +67,15 @@ namespace Neo.Plugins
             this.MaxFee = (long)BigDecimal.Parse(section.GetValue("MaxFee", "0.1"), NativeContract.GAS.Decimals).Value;
             this.DisabledMethods = section.GetSection("DisabledMethods").GetChildren().Select(p => p.Get<string>()).ToArray();
             this.MaxConcurrentConnections = section.GetValue("MaxConcurrentConnections", 40);
+        }
+
+        public void UpdateSettings(RpcServerSettings settings)
+        {
+            this.RpcUser = settings.RpcUser;
+            this.RpcPass = settings.RpcPass;
+            this.MaxGasInvoke = settings.MaxGasInvoke;
+            this.MaxFee = settings.MaxFee;
+            this.DisabledMethods = settings.DisabledMethods;
         }
     }
 }

--- a/src/RpcServer/RpcServerSettings.cs
+++ b/src/RpcServer/RpcServerSettings.cs
@@ -1,11 +1,12 @@
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Neo.SmartContract.Native;
+using System;
 using System.Linq;
 using System.Net;
 
 namespace Neo.Plugins
 {
-    internal class Settings
+    public class RpcServerSettings
     {
         public IPAddress BindAddress { get; }
         public ushort Port { get; }
@@ -19,9 +20,32 @@ namespace Neo.Plugins
         public string[] DisabledMethods { get; }
         public int MaxConcurrentConnections { get; }
 
-        public static Settings Default { get; private set; }
+        public RpcServerSettings(IPAddress bindAddress = null,
+            ushort port = 10332,
+            string sslCert = "",
+            string sslCertPassword = "",
+            string[] trustedAuthorities = null,
+            string rpcUser = "",
+            string rpcPass = "",
+            string masGasInvoke = "10",
+            string maxFee = "0.1",
+            string[] disabledMethods = null,
+            int maxConcurrentConnections = 40)
+        {
+            this.BindAddress = bindAddress ?? IPAddress.Loopback;
+            this.Port = port;
+            this.SslCert = sslCert;
+            this.SslCertPassword = sslCertPassword;
+            this.TrustedAuthorities = trustedAuthorities ?? Array.Empty<string>();
+            this.RpcUser = rpcUser;
+            this.RpcPass = rpcPass;
+            this.MaxGasInvoke = (long)BigDecimal.Parse(masGasInvoke, NativeContract.GAS.Decimals).Value;
+            this.MaxFee = (long)BigDecimal.Parse(maxFee, NativeContract.GAS.Decimals).Value;
+            this.DisabledMethods = disabledMethods ?? Array.Empty<string>();
+            this.MaxConcurrentConnections = maxConcurrentConnections;
+        }
 
-        private Settings(IConfigurationSection section)
+        public RpcServerSettings(IConfigurationSection section)
         {
             this.BindAddress = IPAddress.Parse(section.GetSection("BindAddress").Value);
             this.Port = ushort.Parse(section.GetSection("Port").Value);
@@ -34,11 +58,6 @@ namespace Neo.Plugins
             this.MaxFee = (long)BigDecimal.Parse(section.GetValue("MaxFee", "0.1"), NativeContract.GAS.Decimals).Value;
             this.DisabledMethods = section.GetSection("DisabledMethods").GetChildren().Select(p => p.Get<string>()).ToArray();
             this.MaxConcurrentConnections = section.GetValue("MaxConcurrentConnections", 40);
-        }
-
-        public static void Load(IConfigurationSection section)
-        {
-            Default = new Settings(section);
         }
     }
 }


### PR DESCRIPTION
This PR modifies the RpcServer plugin so that it can be used and configured independently of the disk-based plugin infrastructure of neo-cli. Neo-express does not use the same file based plugin configuration that neo-cli does, yet needs to be able to configure and run some of the standard plugins such as RpcServer.

In particular, this PR:
* separates plugin load functionality out into separate RpcServerPlugin class
* eliminates shared settings state in favour of injecting settings via constructor parameter
* enabled construction of RpcServerSettings instance w/o requiring IConfigurationSection

fixes #203 

