### PR TITLE
[neox-2.x] use snapshot clone

### DIFF
--- a/RpcNep5Tracker/RpcNep5Tracker.cs
+++ b/RpcNep5Tracker/RpcNep5Tracker.cs
@@ -192,7 +192,7 @@ namespace Neo.Plugins
                     script = sb.ToArray();
                 }
 
-                using (ApplicationEngine engine = ApplicationEngine.Run(script, snapshot, extraGAS: maxGas))
+                using (ApplicationEngine engine = ApplicationEngine.Run(script, snapshot.Clone(), extraGAS: maxGas))
                 {
                     if (engine.State.HasFlag(VMState.FAULT)) continue;
                     if (engine.ResultStack.Count <= 0) continue;


### PR DESCRIPTION
Close https://github.com/neo-project/neo/issues/1683 
Close #258
Close #184

To avoid `storages` difference between installed `RpcNep5Tracker` and not.

@shargon @erikzhang 
I change https://github.com/neo-project/neo/pull/1686 to this.