### PR TITLE
create helper applog JSON functions for reuse in neo-express

### DIFF
--- a/src/ApplicationLogs/LogReader.cs
+++ b/src/ApplicationLogs/LogReader.cs
@@ -65,6 +65,7 @@ namespace Neo.Plugins
             JObject trigger = new JObject();
             trigger["trigger"] = appExec.Trigger;
             trigger["vmstate"] = appExec.VMState;
+            trigger["exception"] = GetExceptionMessage(appExec.Exception);
             trigger["gasconsumed"] = appExec.GasConsumed.ToString();
             try
             {
@@ -168,6 +169,18 @@ namespace Neo.Plugins
         public bool ShouldThrowExceptionFromCommit(Exception ex)
         {
             return false;
+        }
+
+        static string GetExceptionMessage(Exception exception)
+        {
+            if (exception == null) return "Engine faulted.";
+
+            if (exception.InnerException != null)
+            {
+                return GetExceptionMessage(exception.InnerException);
+            }
+
+            return exception.Message;
         }
     }
 }

--- a/src/ApplicationLogs/LogReader.cs
+++ b/src/ApplicationLogs/LogReader.cs
@@ -56,48 +56,46 @@ namespace Neo.Plugins
             return raw;
         }
 
-        public void OnPersist(StoreView snapshot, IReadOnlyList<Blockchain.ApplicationExecuted> applicationExecutedList)
+        public static JObject TxLogToJson(Blockchain.ApplicationExecuted appExec)
         {
-            WriteBatch writeBatch = new WriteBatch();
+            global::System.Diagnostics.Debug.Assert(appExec.Transaction != null);
 
-            //processing log for transactions
-            foreach (var appExec in applicationExecutedList.Where(p => p.Transaction != null))
+            var txJson = new JObject();
+            txJson["txid"] = appExec.Transaction.Hash.ToString();
+            JObject trigger = new JObject();
+            trigger["trigger"] = appExec.Trigger;
+            trigger["vmstate"] = appExec.VMState;
+            trigger["gasconsumed"] = appExec.GasConsumed.ToString();
+            try
             {
-                var txJson = new JObject();
-                txJson["txid"] = appExec.Transaction.Hash.ToString();
-                JObject trigger = new JObject();
-                trigger["trigger"] = appExec.Trigger;
-                trigger["vmstate"] = appExec.VMState;
-                trigger["gasconsumed"] = appExec.GasConsumed.ToString();
+                trigger["stack"] = appExec.Stack.Select(q => q.ToJson()).ToArray();
+            }
+            catch (InvalidOperationException)
+            {
+                trigger["stack"] = "error: recursive reference";
+            }
+            trigger["notifications"] = appExec.Notifications.Select(q =>
+            {
+                JObject notification = new JObject();
+                notification["contract"] = q.ScriptHash.ToString();
+                notification["eventname"] = q.EventName;
                 try
                 {
-                    trigger["stack"] = appExec.Stack.Select(q => q.ToJson()).ToArray();
+                    notification["state"] = q.State.ToJson();
                 }
                 catch (InvalidOperationException)
                 {
-                    trigger["stack"] = "error: recursive reference";
+                    notification["state"] = "error: recursive reference";
                 }
-                trigger["notifications"] = appExec.Notifications.Select(q =>
-                {
-                    JObject notification = new JObject();
-                    notification["contract"] = q.ScriptHash.ToString();
-                    notification["eventname"] = q.EventName;
-                    try
-                    {
-                        notification["state"] = q.State.ToJson();
-                    }
-                    catch (InvalidOperationException)
-                    {
-                        notification["state"] = "error: recursive reference";
-                    }
-                    return notification;
-                }).ToArray();
+                return notification;
+            }).ToArray();
 
-                txJson["executions"] = new List<JObject>() { trigger }.ToArray();
-                writeBatch.Put(appExec.Transaction.Hash.ToArray(), Utility.StrictUTF8.GetBytes(txJson.ToString()));
-            }
+            txJson["executions"] = new List<JObject>() { trigger }.ToArray();
+            return txJson;
+        }
 
-            //processing log for block
+        public static JObject BlockLogToJson(StoreView snapshot, IReadOnlyList<Blockchain.ApplicationExecuted> applicationExecutedList)
+        {
             var blocks = applicationExecutedList.Where(p => p.Transaction == null);
             if (blocks.Count() > 0)
             {
@@ -137,7 +135,28 @@ namespace Neo.Plugins
                     triggerList.Add(trigger);
                 }
                 blockJson["executions"] = triggerList.ToArray();
-                writeBatch.Put(blockHash, Utility.StrictUTF8.GetBytes(blockJson.ToString()));
+                return blockJson;
+            }
+
+            return null;
+        }
+
+        public void OnPersist(StoreView snapshot, IReadOnlyList<Blockchain.ApplicationExecuted> applicationExecutedList)
+        {
+            WriteBatch writeBatch = new WriteBatch();
+
+            //processing log for transactions
+            foreach (var appExec in applicationExecutedList.Where(p => p.Transaction != null))
+            {
+                var txJson = TxLogToJson(appExec);
+                writeBatch.Put(appExec.Transaction.Hash.ToArray(), Utility.StrictUTF8.GetBytes(txJson.ToString()));
+            }
+
+            //processing log for block
+            var blockJson = BlockLogToJson(snapshot, applicationExecutedList);
+            if (blockJson != null)
+            {
+                writeBatch.Put(snapshot.PersistingBlock.Hash.ToArray(), Utility.StrictUTF8.GetBytes(blockJson.ToString()));
             }
             db.Write(WriteOptions.Default, writeBatch);
         }


### PR DESCRIPTION
NeoExpress has it's own implementation of standard neo plugins, including ApplicationLog. This PR separates out the logic that converts Blockchain.ApplicationExecuted to JSON so neo-express can reuse it