### PR TITLE
Fix the bug that GAS accuracy is not uniform

### DIFF
--- a/src/RpcServer/RpcServer.Wallet.cs
+++ b/src/RpcServer/RpcServer.Wallet.cs
@@ -121,7 +121,8 @@ namespace Neo.Plugins
             byte[] tx = Convert.FromBase64String(_params[0].AsString());
 
             JObject account = new JObject();
-            account["networkfee"] = (wallet ?? new DummyWallet()).CalculateNetworkFee(Blockchain.Singleton.GetSnapshot(), tx.AsSerializable<Transaction>());
+            long networkfee = (wallet ?? new DummyWallet()).CalculateNetworkFee(Blockchain.Singleton.GetSnapshot(), tx.AsSerializable<Transaction>());
+            account["networkfee"] = new BigDecimal(new BigInteger(networkfee), NativeContract.GAS.Decimals).ToString();
             return account;
         }
 


### PR DESCRIPTION
before
```json
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": {
        "networkfee": 2384840
    }
}
```
↓
after
```json
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": {
        "networkfee": 0.2384840
    }
}
```