### PR TITLE
fix insufficient networkfee in RpcClient

### DIFF
--- a/src/RpcClient/RpcClient.cs
+++ b/src/RpcClient/RpcClient.cs
@@ -5,6 +5,7 @@ using Neo.Network.P2P.Payloads;
 using Neo.Network.RPC.Models;
 using Neo.SmartContract;
 using Neo.SmartContract.Manifest;
+using Neo.SmartContract.Native;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -264,7 +265,7 @@ namespace Neo.Network.RPC
         {
             var json = await RpcSendAsync(GetRpcName(), Convert.ToBase64String(tx.ToArray()))
                 .ConfigureAwait(false);
-            return (long)json["networkfee"].AsNumber();
+            return (long)BigDecimal.Parse(json["networkfee"].AsString(), NativeContract.GAS.Decimals).Value;
         }
 
         /// <summary>

--- a/tests/Neo.Network.RPC.Tests/UT_TransactionManager.cs
+++ b/tests/Neo.Network.RPC.Tests/UT_TransactionManager.cs
@@ -48,7 +48,7 @@ namespace Neo.Network.RPC.Tests
 
             // calculatenetworkfee
             var networkfee = new JObject();
-            networkfee["networkfee"] = 100000000;
+            networkfee["networkfee"] = 1;
             mockRpc.Setup(p => p.RpcSendAsync("calculatenetworkfee", It.Is<JObject[]>(u => true)))
                 .ReturnsAsync(networkfee)
                 .Verifiable();
@@ -81,7 +81,7 @@ namespace Neo.Network.RPC.Tests
 
             // calculatenetworkfee
             var networkfee = new JObject();
-            networkfee["networkfee"] = 100000000;
+            networkfee["networkfee"] = 1;
             mockRpc.Setup(p => p.RpcSendAsync("calculatenetworkfee", It.Is<JObject[]>(u => true)))
                 .ReturnsAsync(networkfee)
                 .Verifiable();


### PR DESCRIPTION
The decimal of network fee in RpcClient and RpcServer is different, resulting in `insuffient funds` exception.