### PR TITLE
[StateService] Fix stateroot witness

### DIFF
--- a/src/StateService/Network/StateRoot.cs
+++ b/src/StateService/Network/StateRoot.cs
@@ -15,6 +15,7 @@ namespace Neo.Plugins.StateService.Network
     class StateRoot : IVerifiable
     {
         public const byte CurrentVersion = 0x00;
+        
         public byte Version;
         public uint Index;
         public UInt256 RootHash;

--- a/src/StateService/Network/StateRoot.cs
+++ b/src/StateService/Network/StateRoot.cs
@@ -15,7 +15,7 @@ namespace Neo.Plugins.StateService.Network
     class StateRoot : IVerifiable
     {
         public const byte CurrentVersion = 0x00;
-        
+
         public byte Version;
         public uint Index;
         public UInt256 RootHash;
@@ -57,12 +57,12 @@ namespace Neo.Plugins.StateService.Network
         {
             DeserializeUnsigned(reader);
             Witness[] witnesses = reader.ReadSerializableArray<Witness>(1);
-            if (witnesses.Length == 0)
-                Witness = null;
-            else if (witnesses.Length == 1)
-                Witness = witnesses[0];
-            else
-                throw new FormatException();
+            Witness = witnesses.Length switch
+            {
+                0 => null,
+                1 => witnesses[0],
+                _ => throw new FormatException(),
+            };
         }
 
         public void DeserializeUnsigned(BinaryReader reader)

--- a/src/StateService/Storage/StateStore.cs
+++ b/src/StateService/Storage/StateStore.cs
@@ -139,6 +139,7 @@ namespace Neo.Plugins.StateService.Storage
             UInt256 root_hash = state_snapshot.Trie.Root.Hash;
             StateRoot state_root = new StateRoot
             {
+                Version = StateRoot.CurrentVersion,
                 Index = height,
                 RootHash = root_hash,
                 Witness = null,


### PR DESCRIPTION
`Witness` in `StateRoot` can be `null`. Because local calculated state root doesn't have witness, it's a placeholder for waiting verified state root which has witness.

Here is local `StateRoot`:
https://github.com/neo-project/neo-modules/blob/16fad3b1a845a858570420bc77f1610516eb6150/src/StateService/Storage/StateStore.cs#L140-L145