### PR TITLE
[RpcService] add server

### DIFF
--- a/src/RpcServer/RpcServerPlugin.cs
+++ b/src/RpcServer/RpcServerPlugin.cs
@@ -43,6 +43,7 @@ namespace Neo.Plugins
             }
 
             server.StartRpcServer();
+            servers.TryAdd(s.Network, server);
         }
 
         public static void RegisterMethods(object handler, uint network)


### PR DESCRIPTION
Fix plugin can't register rpc methods if it is loaded after rpc server.