### PR TITLE
Fix State Autoverify when Oracle Service Unavailable

### DIFF
--- a/src/OracleService/OracleService.cs
+++ b/src/OracleService/OracleService.cs
@@ -108,8 +108,16 @@ namespace Neo.Plugins
                 Console.WriteLine("Please open wallet first!");
                 return;
             }
-            if (!CheckOracleAvaiblable(System.StoreView, out ECPoint[] oracles)) throw new ArgumentException("The oracle service is unavailable");
-            if (!CheckOracleAccount(wallet, oracles)) throw new ArgumentException("There is no oracle account in wallet");
+            if (!CheckOracleAvaiblable(System.StoreView, out ECPoint[] oracles))
+            {
+                Console.WriteLine("The oracle service is unavailable");
+                return;
+            }
+            if (!CheckOracleAccount(wallet, oracles))
+            {
+                Console.WriteLine("There is no oracle account in wallet");
+                return;
+            }
 
             this.wallet = wallet;
             started = true;


### PR DESCRIPTION
The case is when designate State Service node and not designate Oracle service node, both oracle and state with autostart, then start the node. It will throw an exception with "oracle service is unavailable" and state service start failed.