### PR TITLE
[Oracle] Optimize neofs return type

### DIFF
--- a/src/OracleService/OracleService.csproj
+++ b/src/OracleService/OracleService.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Neo.ConsoleService" Version="1.0.0" />
-    <PackageReference Include="NeoFS.API" Version="0.0.24" />
+    <PackageReference Include="NeoFS.API" Version="0.0.27" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OracleService/Protocols/OracleNeoFSProtocol.cs
+++ b/src/OracleService/Protocols/OracleNeoFSProtocol.cs
@@ -51,11 +51,15 @@ namespace Neo.Plugins
             }
         }
 
-        /*
-            GetAsync returns neofs object from the provided url.
-            URI scheme is "neofs:<Container-ID>/<Object-ID>/<Command>/<offset|length>".
-            If Command is not provided, full object is requested.
-        */
+
+        /// <summary>
+        /// GetAsync returns neofs object from the provided url.
+        /// If Command is not provided, full object is requested.
+        /// </summary>
+        /// <param name="uri">URI scheme is "neofs:<Container-ID>/<Object-ID>/<Command>/<offset|length>".</param>
+        /// <param name="host">Client host.</param>
+        /// <param name="cancellation">Cancellation token object.</param>
+        /// <returns>Returns neofs object.</returns>
         private Task<string> GetAsync(Uri uri, string host, CancellationToken cancellation)
         {
             string[] ps = uri.AbsolutePath.Split("/");

--- a/src/OracleService/Protocols/OracleNeoFSProtocol.cs
+++ b/src/OracleService/Protocols/OracleNeoFSProtocol.cs
@@ -84,7 +84,7 @@ namespace Neo.Plugins
         private static async Task<string> GetPayloadAsync(Client client, Address addr, CancellationToken cancellation)
         {
             Object obj = await client.GetObject(cancellation, new GetObjectParams() { Address = addr }, new CallOptions { Ttl = 2 });
-            return Convert.ToBase64String(obj.Payload.ToByteArray());
+            return Utility.StrictUTF8.GetString(obj.Payload.ToByteArray());
         }
 
         private static async Task<string> GetRangeAsync(Client client, Address addr, string[] ps, CancellationToken cancellation)

--- a/src/OracleService/Protocols/OracleNeoFSProtocol.cs
+++ b/src/OracleService/Protocols/OracleNeoFSProtocol.cs
@@ -3,6 +3,7 @@ using Neo.FileSystem.API.Client;
 using Neo.FileSystem.API.Client.ObjectParams;
 using Neo.FileSystem.API.Cryptography;
 using Neo.FileSystem.API.Refs;
+using Neo.IO.Json;
 using Neo.Network.P2P.Payloads;
 using Neo.Wallets;
 using System;
@@ -102,7 +103,7 @@ namespace Neo.Plugins
         private static async Task<string> GetHeaderAsync(Client client, Address addr, CancellationToken cancellation)
         {
             var obj = await client.GetObjectHeader(cancellation, new ObjectHeaderParams() { Address = addr }, new CallOptions { Ttl = 2 });
-            return obj.ToString();
+            return JObject.Parse(obj.ToString()).ToString();
         }
 
         private static async Task<string> GetHashAsync(Client client, Address addr, string[] ps, CancellationToken cancellation)

--- a/src/OracleService/Protocols/OracleNeoFSProtocol.cs
+++ b/src/OracleService/Protocols/OracleNeoFSProtocol.cs
@@ -110,12 +110,12 @@ namespace Neo.Plugins
             if (ps.Length == 0 || ps[0] == "")
             {
                 Object obj = await client.GetObjectHeader(cancellation, new ObjectHeaderParams() { Address = addr }, new CallOptions { Ttl = 2 });
-                return Convert.ToBase64String(obj.PayloadChecksum.Sum.ToByteArray());
+                return $"\"{new UInt256(obj.PayloadChecksum.Sum.ToByteArray())}\"";
             }
             Range range = ParseRange(ps[0]);
             List<byte[]> hashes = await client.GetObjectPayloadRangeHash(cancellation, new RangeChecksumParams() { Address = addr, Ranges = new List<Range>() { range }, Type = ChecksumType.Sha256, Salt = Array.Empty<byte>() }, new CallOptions { Ttl = 2 });
             if (hashes.Count == 0) throw new Exception("empty response, object range is invalid (expected 'Offset|Length')");
-            return Convert.ToBase64String(hashes[0]);
+            return $"\"{new UInt256(hashes[0])}\"";
         }
 
         private static Range ParseRange(string s)

--- a/src/OracleService/Protocols/OracleNeoFSProtocol.cs
+++ b/src/OracleService/Protocols/OracleNeoFSProtocol.cs
@@ -88,7 +88,7 @@ namespace Neo.Plugins
         private static async Task<string> GetPayloadAsync(Client client, Address addr, CancellationToken cancellation)
         {
             Object obj = await client.GetObject(cancellation, new GetObjectParams() { Address = addr }, new CallOptions { Ttl = 2 });
-            return Utility.StrictUTF8.GetString(obj.Payload.ToByteArray());
+            return obj.Payload.ToString(Utility.StrictUTF8);
         }
 
         private static async Task<string> GetRangeAsync(Client client, Address addr, string[] ps, CancellationToken cancellation)
@@ -96,13 +96,13 @@ namespace Neo.Plugins
             if (ps.Length == 0) throw new FormatException("missing object range (expected 'Offset|Length')");
             Range range = ParseRange(ps[0]);
             var res = await client.GetObjectPayloadRangeData(cancellation, new RangeDataParams() { Address = addr, Range = range }, new CallOptions { Ttl = 2 });
-            return Convert.ToBase64String(res);
+            return Utility.StrictUTF8.GetString(res);
         }
 
         private static async Task<string> GetHeaderAsync(Client client, Address addr, CancellationToken cancellation)
         {
             var obj = await client.GetObjectHeader(cancellation, new ObjectHeaderParams() { Address = addr }, new CallOptions { Ttl = 2 });
-            return obj.ToString();
+            return obj.Payload.ToString(Utility.StrictUTF8);
         }
 
         private static async Task<string> GetHashAsync(Client client, Address addr, string[] ps, CancellationToken cancellation)

--- a/src/OracleService/Protocols/OracleNeoFSProtocol.cs
+++ b/src/OracleService/Protocols/OracleNeoFSProtocol.cs
@@ -102,7 +102,7 @@ namespace Neo.Plugins
         private static async Task<string> GetHeaderAsync(Client client, Address addr, CancellationToken cancellation)
         {
             var obj = await client.GetObjectHeader(cancellation, new ObjectHeaderParams() { Address = addr }, new CallOptions { Ttl = 2 });
-            return obj.Payload.ToString(Utility.StrictUTF8);
+            return obj.ToString();
         }
 
         private static async Task<string> GetHashAsync(Client client, Address addr, string[] ps, CancellationToken cancellation)

--- a/src/OracleService/Protocols/OracleNeoFSProtocol.cs
+++ b/src/OracleService/Protocols/OracleNeoFSProtocol.cs
@@ -1,8 +1,8 @@
 using Neo.Cryptography.ECC;
-using Neo.FileSystem.API.Client;
-using Neo.FileSystem.API.Client.ObjectParams;
-using Neo.FileSystem.API.Cryptography;
-using Neo.FileSystem.API.Refs;
+using Neo.FileStorage.API.Client;
+using Neo.FileStorage.API.Client.ObjectParams;
+using Neo.FileStorage.API.Cryptography;
+using Neo.FileStorage.API.Refs;
 using Neo.IO.Json;
 using Neo.Network.P2P.Payloads;
 using Neo.Wallets;
@@ -12,8 +12,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
-using Object = Neo.FileSystem.API.Object.Object;
-using Range = Neo.FileSystem.API.Object.Range;
+using Object = Neo.FileStorage.API.Object.Object;
+using Range = Neo.FileStorage.API.Object.Range;
 
 namespace Neo.Plugins
 {
@@ -103,7 +103,7 @@ namespace Neo.Plugins
         private static async Task<string> GetHeaderAsync(Client client, Address addr, CancellationToken cancellation)
         {
             var obj = await client.GetObjectHeader(cancellation, new ObjectHeaderParams() { Address = addr }, new CallOptions { Ttl = 2 });
-            return JObject.Parse(obj.ToString()).ToString();
+            return obj.ToJson().ToString();
         }
 
         private static async Task<string> GetHashAsync(Client client, Address addr, string[] ps, CancellationToken cancellation)


### PR DESCRIPTION
Currently `filter` can't be applied to neofs results.
 
Changes:
 * Return string from all neofs reponse.
 * Convert `Object` to JSON in `GetHeaderAsync`. 