### PR TITLE
move Settings paramter to dbft plugin ctor

### DIFF
--- a/src/DBFTPlugin/DBFTPlugin.cs
+++ b/src/DBFTPlugin/DBFTPlugin.cs
@@ -14,11 +14,18 @@ namespace Neo.Consensus
         private NeoSystem neoSystem;
         private Settings settings;
 
+        public DBFTPlugin() { }
+
+        public DBFTPlugin(Settings settings)
+        {
+            this.settings = settings;
+        }
+
         public override string Description => "Consensus plugin with dBFT algorithm.";
 
         protected override void Configure()
         {
-            settings = new Settings(GetConfiguration());
+            if (settings == null) settings = new Settings(GetConfiguration());
         }
 
         protected override void OnSystemLoaded(NeoSystem system)
@@ -53,12 +60,11 @@ namespace Neo.Consensus
             Start(walletProvider.GetWallet());
         }
 
-        public void Start(Wallet wallet, Settings settings = null)
+        public void Start(Wallet wallet)
         {
             if (started) return;
             started = true;
-            if (settings != null) this.settings = settings;
-            consensus = neoSystem.ActorSystem.ActorOf(ConsensusService.Props(neoSystem, this.settings, wallet));
+            consensus = neoSystem.ActorSystem.ActorOf(ConsensusService.Props(neoSystem, settings, wallet));
             consensus.Tell(new ConsensusService.Start());
         }
 


### PR DESCRIPTION
DBFT Settings has to be set in the constructor so that the correct settings.Network value is available when OnSystemLoaded is called

Needed for [RC1](https://github.com/neo-project/neo/issues/2329)