### PR TITLE
[OracleService] Update neofs-api

### DIFF
--- a/src/OracleService/OracleService.csproj
+++ b/src/OracleService/OracleService.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Neo.ConsoleService" Version="1.0.0" />
-    <PackageReference Include="NeoFS.API" Version="0.0.27" />
+    <PackageReference Include="NeoFS.API" Version="3.0.0-rc1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Now `neofs-api-csharp` depends on `Neo 3.0.0-rc1`.