### PR TITLE
StatesDumper: fix bug with missing states dumps

### DIFF
--- a/src/StatesDumper/StatesDumper.cs
+++ b/src/StatesDumper/StatesDumper.cs
@@ -53,7 +53,7 @@ namespace Neo.Plugins
         }
 
         private void OnPersistStorage(uint network, DataCache snapshot)
-        {            
+        {
             uint blockIndex = NativeContract.Ledger.CurrentIndex(snapshot);
             if (blockIndex >= Settings.Default.HeightToBegin)
             {
@@ -89,10 +89,10 @@ namespace Neo.Plugins
                 bs_item["block"] = blockIndex;
                 bs_item["size"] = array.Count;
                 bs_item["storage"] = array;
-                if (!bs_cache.TryGetValue(network, out JArray cache)) 
+                if (!bs_cache.TryGetValue(network, out JArray cache))
                 {
                     cache = new JArray();
-                }   
+                }
                 cache.Add(bs_item);
                 bs_cache[network] = cache;
             }

--- a/src/StatesDumper/StatesDumper.cs
+++ b/src/StatesDumper/StatesDumper.cs
@@ -112,7 +112,6 @@ namespace Neo.Plugins
             if ((blockIndex % Settings.Default.BlockCacheSize == 0) || (Settings.Default.HeightToStartRealTimeSyncing != -1 && blockIndex >= Settings.Default.HeightToStartRealTimeSyncing))
             {
                 string path = HandlePaths(network, blockIndex);
-                Directory.CreateDirectory(path);
                 path = $"{path}/dump-block-{blockIndex}.json";
                 File.WriteAllText(path, cache.ToString());
                 cache.Clear();

--- a/src/StatesDumper/StatesDumper.cs
+++ b/src/StatesDumper/StatesDumper.cs
@@ -53,8 +53,7 @@ namespace Neo.Plugins
         }
 
         private void OnPersistStorage(uint network, DataCache snapshot)
-        {
-            if (!bs_cache.TryGetValue(network, out JArray cache)) return;
+        {            
             uint blockIndex = NativeContract.Ledger.CurrentIndex(snapshot);
             if (blockIndex >= Settings.Default.HeightToBegin)
             {
@@ -90,7 +89,12 @@ namespace Neo.Plugins
                 bs_item["block"] = blockIndex;
                 bs_item["size"] = array.Count;
                 bs_item["storage"] = array;
+                if (!bs_cache.TryGetValue(network, out JArray cache)) 
+                {
+                    cache = new JArray();
+                }   
                 cache.Add(bs_item);
+                bs_cache[network] = cache;
             }
         }
 


### PR DESCRIPTION
### Problem

StatesDumper does not save states dumps (because of https://github.com/neo-project/neo-modules/pull/517 changes).

### Solution

We need to put states to `bs_cache` even if it's empty.