### PR TITLE
Use only one flag to indicate Oracle started status

### DIFF
--- a/src/OracleService/OracleService.cs
+++ b/src/OracleService/OracleService.cs
@@ -127,6 +127,11 @@ namespace Neo.Plugins
         [ConsoleCommand("stop oracle", Category = "Oracle", Description = "Stop oracle service")]
         private void OnStop()
         {
+            if (!started)
+            {
+                Console.WriteLine("Oracle service is not started");
+                return;
+            }
             cancelSource.Cancel();
             if (timer != null)
             {


### PR DESCRIPTION
I am wondering why we need both `started` and `stopped` flags. Isn't `stopped` equal to NOT `started`?