### PR TITLE
fix crash issue when `RpcServer` is not installed

### DIFF
--- a/src/StateService/StatePlugin.cs
+++ b/src/StateService/StatePlugin.cs
@@ -42,7 +42,14 @@ namespace Neo.Plugins.StateService
             System = system;
             Store = System.ActorSystem.ActorOf(StateStore.Props(this, string.Format(Settings.Default.Path, system.Settings.Network.ToString("X8"))));
             System.ServiceAdded += NeoSystem_ServiceAdded;
-            RpcServerPlugin.RegisterMethods(this, Settings.Default.Network);
+            try
+            {
+                RpcServerPlugin.RegisterMethods(this, Settings.Default.Network);
+            }
+            catch
+            {
+                Console.WriteLine("Please install RpcServer plugin.");
+            }
         }
 
         private void NeoSystem_ServiceAdded(object sender, object service)


### PR DESCRIPTION
When plugin `StateService` is installed  but `RpcServer` is not installed, `neo-cli` will crash every time we start `neo-cli` with error message:

```C#
Unhandled exception. NEO-CLI v3.0.1  -  NEO v3.0.1  -  NEO-VM v3.0.0

neo> System.IO.FileNotFoundException: Could not load file or assembly 'RpcServer, Version=3.0.1.0, Culture=neutral, PublicKeyToken=null'. ???????????
File name: 'RpcServer, Version=3.0.1.0, Culture=neutral, PublicKeyToken=null'
   at Neo.Plugins.StateService.StatePlugin.OnSystemLoaded(NeoSystem system)
   at Neo.NeoSystem..ctor(ProtocolSettings settings, String storageEngine, String storagePath)
   at Neo.CLI.MainService.Start(String[] args)
   at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__140_1(Object state)
   at System.Threading.QueueUserWorkItemCallbackDefaultContext.Execute()
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback()
```