### PR TITLE
update Console to ConsoleHelper

### DIFF
--- a/src/OracleService/OracleService.cs
+++ b/src/OracleService/OracleService.cs
@@ -104,17 +104,17 @@ namespace Neo.Plugins
 
             if (wallet is null)
             {
-                Console.WriteLine("Please open wallet first!");
+                ConsoleHelper.Warning("Please open wallet first!");
                 return;
             }
             if (!CheckOracleAvaiblable(System.StoreView, out ECPoint[] oracles))
             {
-                Console.WriteLine("The oracle service is unavailable");
+                ConsoleHelper.Warning("The oracle service is unavailable");
                 return;
             }
             if (!CheckOracleAccount(wallet, oracles))
             {
-                Console.WriteLine("There is no oracle account in wallet");
+                ConsoleHelper.Warning("There is no oracle account in wallet");
                 return;
             }
 
@@ -123,7 +123,7 @@ namespace Neo.Plugins
             protocols["neofs"] = new OracleNeoFSProtocol(wallet, oracles);
             status = OracleStatus.Running;
             timer = new Timer(OnTimer, null, RefreshIntervalMilliSeconds, Timeout.Infinite);
-            Console.WriteLine($"Oracle started");
+            ConsoleHelper.Info($"Oracle started");
             ProcessRequestsAsync();
         }
 
@@ -142,7 +142,7 @@ namespace Neo.Plugins
         [ConsoleCommand("oracle status", Category = "Oracle", Description = "Show oracle status")]
         private void OnShow()
         {
-            Console.WriteLine($"Oracle status: {status}");
+            ConsoleHelper.Info($"Oracle status: ", $"{status}");
         }
 
         void IPersistencePlugin.OnPersist(NeoSystem system, Block block, DataCache snapshot, IReadOnlyList<Blockchain.ApplicationExecuted> applicationExecutedList)

--- a/src/StateService/StatePlugin.cs
+++ b/src/StateService/StatePlugin.cs
@@ -94,12 +94,12 @@ namespace Neo.Plugins.StateService
         {
             if (Verifier is not null)
             {
-                Console.WriteLine("Already started!");
+                ConsoleHelper.Warning("Already started!");
                 return;
             }
             if (wallet is null)
             {
-                Console.WriteLine("Please open wallet first!");
+                ConsoleHelper.Warning("Please open wallet first!");
                 return;
             }
             Verifier = System.ActorSystem.ActorOf(VerificationService.Props(wallet));
@@ -112,16 +112,19 @@ namespace Neo.Plugins.StateService
             using var snapshot = StateStore.Singleton.GetSnapshot();
             StateRoot state_root = snapshot.GetStateRoot(index);
             if (state_root is null)
-                Console.WriteLine("Unknown state root");
+                ConsoleHelper.Warning("Unknown state root");
             else
-                Console.WriteLine(state_root.ToJson());
+                ConsoleHelper.Info(state_root.ToJson().ToString());
         }
 
         [ConsoleCommand("state height", Category = "StateService", Description = "Get current state root index")]
         private void OnGetStateHeight()
         {
             if (System is null || System.Settings.Network != Settings.Default.Network) throw new InvalidOperationException("Network doesn't match");
-            Console.WriteLine($"LocalRootIndex: {StateStore.Singleton.LocalRootIndex}, ValidatedRootIndex: {StateStore.Singleton.ValidatedRootIndex}");
+            ConsoleHelper.Info("LocalRootIndex: ",
+                $"{StateStore.Singleton.LocalRootIndex}",
+                " ValidatedRootIndex: ",
+                $"{StateStore.Singleton.ValidatedRootIndex}");
         }
 
         [ConsoleCommand("get proof", Category = "StateService", Description = "Get proof of key and contract hash")]
@@ -130,11 +133,11 @@ namespace Neo.Plugins.StateService
             if (System is null || System.Settings.Network != Settings.Default.Network) throw new InvalidOperationException("Network doesn't match");
             try
             {
-                Console.WriteLine(GetProof(root_hash, script_hash, Convert.FromBase64String(key)));
+                ConsoleHelper.Info("Proof: ", GetProof(root_hash, script_hash, Convert.FromBase64String(key)));
             }
             catch (RpcException e)
             {
-                Console.WriteLine(e.Message);
+                ConsoleHelper.Error(e.Message);
             }
         }
 
@@ -143,11 +146,12 @@ namespace Neo.Plugins.StateService
         {
             try
             {
-                Console.WriteLine(VerifyProof(root_hash, Convert.FromBase64String(proof)));
+                ConsoleHelper.Info("Verify Result: ",
+                    VerifyProof(root_hash, Convert.FromBase64String(proof)));
             }
             catch (RpcException e)
             {
-                Console.WriteLine(e.Message);
+                ConsoleHelper.Error(e.Message);
             }
         }
 

--- a/src/StatesDumper/StatesDumper.cs
+++ b/src/StatesDumper/StatesDumper.cs
@@ -51,7 +51,10 @@ namespace Neo.Plugins
                 ["value"] = Convert.ToBase64String(p.Value.ToArray())
             }));
             File.WriteAllText(path, array.ToString());
-            Console.WriteLine($"States ({array.Count}) have been dumped into file {path}");
+            ConsoleHelper.Info("States",
+                $"({array.Count})",
+                " have been dumped into file ",
+                $"{path}");
         }
 
         void IPersistencePlugin.OnPersist(NeoSystem system, Block block, DataCache snapshot, IReadOnlyList<Blockchain.ApplicationExecuted> applicationExecutedList)
@@ -128,7 +131,7 @@ namespace Neo.Plugins
 
         bool IPersistencePlugin.ShouldThrowExceptionFromCommit(Exception ex)
         {
-            Console.WriteLine($"Error writing States with StatesDumper.{Environment.NewLine}{ex}");
+            ConsoleHelper.Error($"Error writing States with StatesDumper.{Environment.NewLine}{ex}");
             return true;
         }
 


### PR DESCRIPTION
Since the `Neo.ConsoleService` is updated to version 1.2, we should use the new `ConsoleHelper`.