### PR TITLE
dbft: tune MaxBlock* parameters

### DIFF
--- a/src/DBFTPlugin/DBFTPlugin/config.json
+++ b/src/DBFTPlugin/DBFTPlugin/config.json
@@ -4,7 +4,7 @@
     "IgnoreRecoveryLogs": false,
     "AutoStart": false,
     "Network": 860833102,
-    "MaxBlockSize": 262144,
-    "MaxBlockSystemFee": 900000000000
+    "MaxBlockSize": 2097152,
+    "MaxBlockSystemFee": 100000000000
   }
 }


### PR DESCRIPTION
Follow ExecFeeFactor changes for MaxBlockSystemFee and make it possible to fit
5K transactions into the block. Related to neo-project/neo-node#850.