### PR TITLE
GetProof shouldn't throw RpcException

### DIFF
--- a/src/StateService/StatePlugin.cs
+++ b/src/StateService/StatePlugin.cs
@@ -185,7 +185,7 @@ namespace Neo.Plugins.StateService
                 Key = key,
             };
             var result = trie.TryGetProof(skey, out var proof);
-            if (!result) throw new RpcException(-100, "Unknown value");
+            if (!result) throw new KeyNotFoundException();
 
             using MemoryStream ms = new();
             using BinaryWriter writer = new(ms, Utility.StrictUTF8);


### PR DESCRIPTION
Update GetProof helper to throw KeyNotFoundException if `trie.TryGetProof` fails. This matches the exception thrown by `GetState` if the key is invalid