### PR TITLE
RpcClient.InvokeScriptAsync doesn't accept Script param

### DIFF
--- a/src/RpcClient/RpcClient.cs
+++ b/src/RpcClient/RpcClient.cs
@@ -14,6 +14,7 @@ using Neo.Network.P2P.Payloads;
 using Neo.Network.RPC.Models;
 using Neo.SmartContract;
 using Neo.SmartContract.Manifest;
+using Neo.VM;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -442,9 +443,9 @@ namespace Neo.Network.RPC
         /// Returns the result after passing a script through the VM.
         /// This RPC call does not affect the blockchain in any way.
         /// </summary>
-        public async Task<RpcInvokeResult> InvokeScriptAsync(byte[] script, params Signer[] signers)
+        public async Task<RpcInvokeResult> InvokeScriptAsync(ReadOnlyMemory<byte> script, params Signer[] signers)
         {
-            List<JObject> parameters = new() { Convert.ToBase64String(script) };
+            List<JObject> parameters = new() { Convert.ToBase64String(script.Span) };
             if (signers.Length > 0)
             {
                 parameters.Add(signers.Select(p => p.ToJson()).ToArray());

--- a/src/RpcClient/TransactionManager.cs
+++ b/src/RpcClient/TransactionManager.cs
@@ -62,13 +62,16 @@ namespace Neo.Network.RPC
         /// <summary>
         /// Helper function for one-off TransactionManager creation
         /// </summary>
-        public static Task<TransactionManager> MakeTransactionAsync(RpcClient rpcClient, byte[] script, Signer[] signers = null, TransactionAttribute[] attributes = null)
+        public static Task<TransactionManager> MakeTransactionAsync(RpcClient rpcClient, ReadOnlyMemory<byte> script, Signer[] signers = null, TransactionAttribute[] attributes = null)
         {
             var factory = new TransactionManagerFactory(rpcClient);
             return factory.MakeTransactionAsync(script, signers, attributes);
         }
 
-        public static Task<TransactionManager> MakeTransactionAsync(RpcClient rpcClient, byte[] script, long systemFee, Signer[] signers = null, TransactionAttribute[] attributes = null)
+        /// <summary>
+        /// Helper function for one-off TransactionManager creation
+        /// </summary>
+        public static Task<TransactionManager> MakeTransactionAsync(RpcClient rpcClient, ReadOnlyMemory<byte> script, long systemFee, Signer[] signers = null, TransactionAttribute[] attributes = null)
         {
             var factory = new TransactionManagerFactory(rpcClient);
             return factory.MakeTransactionAsync(script, systemFee, signers, attributes);

--- a/src/RpcClient/TransactionManagerFactory.cs
+++ b/src/RpcClient/TransactionManagerFactory.cs
@@ -32,15 +32,24 @@ namespace Neo.Network.RPC
         /// Create an unsigned Transaction object with given parameters.
         /// </summary>
         /// <param name="script">Transaction Script</param>
+        /// <param name="signers">Transaction Signers</param>
         /// <param name="attributes">Transaction Attributes</param>
         /// <returns></returns>
-        public async Task<TransactionManager> MakeTransactionAsync(byte[] script, Signer[] signers = null, TransactionAttribute[] attributes = null)
+        public async Task<TransactionManager> MakeTransactionAsync(ReadOnlyMemory<byte> script, Signer[] signers = null, TransactionAttribute[] attributes = null)
         {
             RpcInvokeResult invokeResult = await rpcClient.InvokeScriptAsync(script, signers).ConfigureAwait(false);
             return await MakeTransactionAsync(script, invokeResult.GasConsumed, signers, attributes).ConfigureAwait(false);
         }
 
-        public async Task<TransactionManager> MakeTransactionAsync(byte[] script, long systemFee, Signer[] signers = null, TransactionAttribute[] attributes = null)
+        /// <summary>
+        /// Create an unsigned Transaction object with given parameters.
+        /// </summary>
+        /// <param name="script">Transaction Script</param>
+        /// <param name="systemFee">Transaction System Fee</param>
+        /// <param name="signers">Transaction Signers</param>
+        /// <param name="attributes">Transaction Attributes</param>
+        /// <returns></returns>
+        public async Task<TransactionManager> MakeTransactionAsync(ReadOnlyMemory<byte> script, long systemFee, Signer[] signers = null, TransactionAttribute[] attributes = null)
         {
             uint blockCount = await rpcClient.GetBlockCountAsync().ConfigureAwait(false) - 1;
 


### PR DESCRIPTION
I realize we are up against the wire for 3.3.1, but this is a simple parameter type change to make `RpcClient.InvokeScriptAsync` and `TransactionManagerFactory.MakeTransactionAsync`
compatible with changes to Script that were introduced in Neo.VM 3.3.0

Fixes #720