### PR TITLE
add throwOnError param to RpcClient Send/SendAsync

### DIFF
--- a/src/RpcClient/RpcClient.cs
+++ b/src/RpcClient/RpcClient.cs
@@ -88,12 +88,13 @@ namespace Neo.Network.RPC
                 Params = paraArgs
             };
         }
-        static RpcResponse AsRpcResponse(string content)
+
+        static RpcResponse AsRpcResponse(string content, bool throwOnError)
         {
             var response = RpcResponse.FromJson((JObject)JToken.Parse(content));
             response.RawResponse = content;
 
-            if (response.Error != null)
+            if (response.Error != null && throwOnError)
             {
                 throw new RpcException(response.Error.Code, response.Error.Message);
             }
@@ -110,7 +111,7 @@ namespace Neo.Network.RPC
             };
         }
 
-        public RpcResponse Send(RpcRequest request)
+        public RpcResponse Send(RpcRequest request, bool throwOnError = true)
         {
             if (disposedValue) throw new ObjectDisposedException(nameof(RpcClient));
 
@@ -118,17 +119,17 @@ namespace Neo.Network.RPC
             using var responseMsg = httpClient.Send(requestMsg);
             using var contentStream = responseMsg.Content.ReadAsStream();
             using var contentReader = new StreamReader(contentStream);
-            return AsRpcResponse(contentReader.ReadToEnd());
+            return AsRpcResponse(contentReader.ReadToEnd(), throwOnError);
         }
 
-        public async Task<RpcResponse> SendAsync(RpcRequest request)
+        public async Task<RpcResponse> SendAsync(RpcRequest request, bool throwOnError = true)
         {
             if (disposedValue) throw new ObjectDisposedException(nameof(RpcClient));
 
             using var requestMsg = AsHttpRequest(request);
             using var responseMsg = await httpClient.SendAsync(requestMsg).ConfigureAwait(false);
             var content = await responseMsg.Content.ReadAsStringAsync();
-            return AsRpcResponse(content);
+            return AsRpcResponse(content, throwOnError);
         }
 
         public virtual JToken RpcSend(string method, params JToken[] paraArgs)

--- a/tests/Neo.Network.RPC.Tests/UT_RpcClient.cs
+++ b/tests/Neo.Network.RPC.Tests/UT_RpcClient.cs
@@ -70,6 +70,35 @@ namespace Neo.Network.RPC.Tests
         }
 
         [TestMethod]
+        public async Task TestNoThrowErrorResponse()
+        {
+            var test = TestUtils.RpcTestCases.Find(p => p.Name == (nameof(rpc.SendRawTransactionAsync) + "error").ToLower());
+            handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            handlerMock.Protected()
+               // Setup the PROTECTED method to mock
+               .Setup<Task<HttpResponseMessage>>(
+                  "SendAsync",
+                  ItExpr.IsAny<HttpRequestMessage>(),
+                  ItExpr.IsAny<CancellationToken>())
+               // prepare the expected response of the mocked http call
+               .ReturnsAsync(new HttpResponseMessage()
+               {
+                   StatusCode = HttpStatusCode.OK,
+                   Content = new StringContent(test.Response.ToJson().ToString()),
+               })
+               .Verifiable();
+
+            var httpClient = new HttpClient(handlerMock.Object);
+            var client = new RpcClient(httpClient, new Uri("http://seed1.neo.org:10331"), null);
+            var response = await client.SendAsync(test.Request, false);
+
+            Assert.IsNull(response.Result);
+            Assert.IsNotNull(response.Error);
+            Assert.AreEqual(-500, response.Error.Code);
+            Assert.AreEqual("InsufficientFunds", response.Error.Message);
+        }
+
+        [TestMethod]
         public void TestConstructorByUrlAndDispose()
         {
             //dummy url for test


### PR DESCRIPTION
The FindStates JSON RPC method in the state service API throws a Key Not Found exception when the caller asks for an invalid key. On the calling side, I would like to receive the RpcResponse directly, without letting `AsRpcResponse` automatically throw an exception when the RPcResponse `Error` field is not null