### PR TITLE
Fix prepare request in recovery message

### DIFF
--- a/src/DBFTPlugin/Consensus/ConsensusContext.MakePayload.cs
+++ b/src/DBFTPlugin/Consensus/ConsensusContext.MakePayload.cs
@@ -139,6 +139,7 @@ namespace Neo.Consensus
                     Timestamp = Block.Timestamp,
                     Nonce = Block.Nonce,
                     BlockIndex = Block.Index,
+                    ValidatorIndex = Block.PrimaryIndex,
                     TransactionHashes = TransactionHashes
                 };
             }


### PR DESCRIPTION
`ValidatorIndex` is uninitialized and unassigned in `PrepareRequestMessage` of `RecoveryMessage`. This will cause prepare request reverify failure when recovery.