### PR TITLE
rpc: add FindStorage

### DIFF
--- a/src/RpcServer/RpcServer.Blockchain.cs
+++ b/src/RpcServer/RpcServer.Blockchain.cs
@@ -233,7 +233,6 @@ namespace Neo.Plugins
                         break;
                     }
 
-
                     JObject j = new();
                     j["key"] = Convert.ToBase64String(iter.Current.Key.Key.Span);
                     j["value"] = Convert.ToBase64String(iter.Current.Value.Value.Span);
@@ -241,7 +240,6 @@ namespace Neo.Plugins
                     i++;
                 }
                 json["truncated"] = hasMore;
-
             }
 
             json["next"] = start + i;

--- a/src/RpcServer/RpcServer.Blockchain.cs
+++ b/src/RpcServer/RpcServer.Blockchain.cs
@@ -198,6 +198,58 @@ namespace Neo.Plugins
         }
 
         [RpcMethod]
+        protected virtual JToken FindStorage(JArray _params)
+        {
+            using var snapshot = system.GetSnapshot();
+            if (!int.TryParse(_params[0].AsString(), out int id))
+            {
+                UInt160 hash = UInt160.Parse(_params[0].AsString());
+                ContractState contract = NativeContract.ContractManagement.GetContract(snapshot, hash);
+                if (contract is null) throw new RpcException(-100, "Unknown contract");
+                id = contract.Id;
+            }
+
+            byte[] prefix = Convert.FromBase64String(_params[1].AsString());
+            byte[] prefix_key = StorageKey.CreateSearchPrefix(id, prefix);
+
+            if (!int.TryParse(_params[2].AsString(), out int start))
+            {
+                start = 0;
+            }
+
+            JObject json = new();
+            JArray jarr = new();
+            int pageSize = 50;
+            int i = 0;
+
+            using (var iter = snapshot.Find(prefix_key).Skip(count: start).GetEnumerator())
+            {
+                var hasMore = false;
+                while (iter.MoveNext())
+                {
+                    if (i == pageSize)
+                    {
+                        hasMore = true;
+                        break;
+                    }
+
+
+                    JObject j = new();
+                    j["key"] = Convert.ToBase64String(iter.Current.Key.Key.Span);
+                    j["value"] = Convert.ToBase64String(iter.Current.Value.Value.Span);
+                    jarr.Add(j);
+                    i++;
+                }
+                json["truncated"] = hasMore;
+
+            }
+
+            json["next"] = start + i;
+            json["results"] = jarr;
+            return json;
+        }
+
+        [RpcMethod]
         protected virtual JToken GetTransactionHeight(JArray _params)
         {
             UInt256 hash = UInt256.Parse(_params[0].AsString());

--- a/src/RpcServer/RpcServer.Blockchain.cs
+++ b/src/RpcServer/RpcServer.Blockchain.cs
@@ -219,7 +219,7 @@ namespace Neo.Plugins
 
             JObject json = new();
             JArray jarr = new();
-            int pageSize = 50;
+            int pageSize = settings.FindStoragePageSize;
             int i = 0;
 
             using (var iter = snapshot.Find(prefix_key).Skip(count: start).GetEnumerator())

--- a/src/RpcServer/RpcServer.csproj
+++ b/src/RpcServer/RpcServer.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <PackageId>Neo.Plugins.RpcServer</PackageId>
     <RootNamespace>Neo.Plugins</RootNamespace>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
   
 </Project>

--- a/src/RpcServer/RpcServer.csproj
+++ b/src/RpcServer/RpcServer.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <PackageId>Neo.Plugins.RpcServer</PackageId>
     <RootNamespace>Neo.Plugins</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10</LangVersion>
   </PropertyGroup>
-  
+
 </Project>

--- a/src/RpcServer/Settings.cs
+++ b/src/RpcServer/Settings.cs
@@ -45,6 +45,7 @@ namespace Neo.Plugins
         public string[] DisabledMethods { get; init; }
         public bool SessionEnabled { get; init; }
         public TimeSpan SessionExpirationTime { get; init; }
+        public int FindStoragePageSize { get; init; }
 
         public static RpcServerSettings Default { get; } = new RpcServerSettings
         {
@@ -60,7 +61,8 @@ namespace Neo.Plugins
             DisabledMethods = Array.Empty<string>(),
             MaxConcurrentConnections = 40,
             SessionEnabled = false,
-            SessionExpirationTime = TimeSpan.FromSeconds(60)
+            SessionExpirationTime = TimeSpan.FromSeconds(60),
+            FindStoragePageSize = 50
         };
 
         public static RpcServerSettings Load(IConfigurationSection section) => new()
@@ -80,7 +82,8 @@ namespace Neo.Plugins
             DisabledMethods = section.GetSection("DisabledMethods").GetChildren().Select(p => p.Get<string>()).ToArray(),
             MaxConcurrentConnections = section.GetValue("MaxConcurrentConnections", Default.MaxConcurrentConnections),
             SessionEnabled = section.GetValue("SessionEnabled", Default.SessionEnabled),
-            SessionExpirationTime = TimeSpan.FromSeconds(section.GetValue("SessionExpirationTime", (int)Default.SessionExpirationTime.TotalSeconds))
+            SessionExpirationTime = TimeSpan.FromSeconds(section.GetValue("SessionExpirationTime", (int)Default.SessionExpirationTime.TotalSeconds)),
+            FindStoragePageSize = section.GetValue("FindStoragePageSize", Default.FindStoragePageSize)
         };
     }
 }

--- a/src/RpcServer/config.json
+++ b/src/RpcServer/config.json
@@ -17,7 +17,8 @@
         "MaxStackSize": 65535,
         "DisabledMethods": [ "openwallet" ],
         "SessionEnabled": false,
-        "SessionExpirationTime": 60
+        "SessionExpirationTime": 60,
+        "FindStoragePageSize": 50
       }
     ]
   }


### PR DESCRIPTION
close #758 

Arguments:
1. Similar to `GetStorage()` the first argument is the `contract hash` or `contract id`
2. `search prefix`, base 64 encoded. Can be set to `""` to return all storage.
3. `start` location
    The `pageSize` is currently fixed to 50. If the find results exceed 50 results it shall return the `truncated` key set to `true` and the `next` key set to the `start` location of the next page. This way a consumer can directly use the result of `json["next"]` as 3rd parameter to continue where left off.

Up for discussion:
1. Should the `pageSize` be configurable in the RpcServer config?
2. Should the `pageSize` be configurable as parameter by the invoker?