### PR TITLE
RcpServer: Fixed CORS and Basic Auth

### DIFF
--- a/src/RpcServer/RpcServer.cs
+++ b/src/RpcServer/RpcServer.cs
@@ -52,9 +52,13 @@ namespace Neo.Plugins
         {
             if (string.IsNullOrEmpty(settings.RpcUser)) return true;
 
-            context.Response.Headers["WWW-Authenticate"] = "Basic realm=\"Restricted\"";
-
             string reqauth = context.Request.Headers["Authorization"];
+            if (string.IsNullOrEmpty(reqauth))
+            {
+                context.Response.Headers["WWW-Authenticate"] = "Basic realm=\"Restricted\"";
+                context.Response.StatusCode = 401;
+            }
+
             string authstring;
             try
             {
@@ -129,11 +133,42 @@ namespace Neo.Plugins
             }))
             .Configure(app =>
             {
+                if (settings.EnableCors)
+                    app.UseCors("All");
+
                 app.UseResponseCompression();
                 app.Run(ProcessAsync);
             })
             .ConfigureServices(services =>
             {
+                if (settings.EnableCors)
+                {
+                    if (settings.AllowOrigins.Length == 0)
+                        services.AddCors(options =>
+                        {
+                            options.AddPolicy("All", policy =>
+                            {
+                                policy.AllowAnyOrigin()
+                                .AllowAnyHeader()
+                                .WithMethods("GET", "POST");
+                                // The CORS specification states that setting origins to "*" (all origins)
+                                // is invalid if the Access-Control-Allow-Credentials header is present.
+                                //.AllowCredentials() 
+                            });
+                        });
+                    else
+                        services.AddCors(options =>
+                        {
+                            options.AddPolicy("All", policy =>
+                            {
+                                policy.WithOrigins(settings.AllowOrigins)
+                                .AllowAnyHeader()
+                                .AllowCredentials()
+                                .WithMethods("GET", "POST");
+                            });
+                        });
+                }
+
                 services.AddResponseCompression(options =>
                 {
                     // options.EnableForHttps = false;
@@ -158,10 +193,6 @@ namespace Neo.Plugins
 
         public async Task ProcessAsync(HttpContext context)
         {
-            context.Response.Headers["Access-Control-Allow-Origin"] = "*";
-            context.Response.Headers["Access-Control-Allow-Methods"] = "GET, POST";
-            context.Response.Headers["Access-Control-Allow-Headers"] = "Content-Type";
-            context.Response.Headers["Access-Control-Max-Age"] = "31536000";
             if (context.Request.Method != "GET" && context.Request.Method != "POST") return;
             JToken request = null;
             if (context.Request.Method == "GET")

--- a/src/RpcServer/RpcServerPlugin.cs
+++ b/src/RpcServer/RpcServerPlugin.cs
@@ -42,6 +42,16 @@ namespace Neo.Plugins
             RpcServerSettings s = settings.Servers.FirstOrDefault(p => p.Network == system.Settings.Network);
             if (s is null) return;
 
+            if (s.EnableCors && string.IsNullOrEmpty(s.RpcUser) == false && s.AllowOrigins.Length == 0)
+            {
+                Log("RcpServer: CORS is misconfigured!", LogLevel.Warning);
+                Log($"You have {nameof(s.EnableCors)} and Basic Authentication enabled but " +
+                $"{nameof(s.AllowOrigins)} is empty in config.json for RcpServer. " +
+                "You must add url origins to the list to have CORS work from " +
+                $"browser with basic authentication enabled. " +
+                $"Example: \"AllowOrigins\": [\"http://{s.BindAddress}:{s.Port}\"]", LogLevel.Info);
+            }
+
             RpcServer server = new(system, s);
 
             if (handlers.Remove(s.Network, out var list))

--- a/src/RpcServer/Settings.cs
+++ b/src/RpcServer/Settings.cs
@@ -38,6 +38,8 @@ namespace Neo.Plugins
         public int MaxConcurrentConnections { get; init; }
         public string RpcUser { get; init; }
         public string RpcPass { get; init; }
+        public bool EnableCors { get; init; }
+        public string[] AllowOrigins { get; init; }
         public long MaxGasInvoke { get; init; }
         public long MaxFee { get; init; }
         public int MaxIteratorResultItems { get; init; }
@@ -75,6 +77,8 @@ namespace Neo.Plugins
             TrustedAuthorities = section.GetSection("TrustedAuthorities").GetChildren().Select(p => p.Get<string>()).ToArray(),
             RpcUser = section.GetSection("RpcUser").Value,
             RpcPass = section.GetSection("RpcPass").Value,
+            EnableCors = section.GetValue(nameof(EnableCors), Default.SessionEnabled),
+            AllowOrigins = section.GetSection(nameof(AllowOrigins)).GetChildren().Select(p => p.Get<string>()).ToArray(),
             MaxGasInvoke = (long)new BigDecimal(section.GetValue<decimal>("MaxGasInvoke", Default.MaxGasInvoke), NativeContract.GAS.Decimals).Value,
             MaxFee = (long)new BigDecimal(section.GetValue<decimal>("MaxFee", Default.MaxFee), NativeContract.GAS.Decimals).Value,
             MaxIteratorResultItems = section.GetValue("MaxIteratorResultItems", Default.MaxIteratorResultItems),

--- a/src/RpcServer/config.json
+++ b/src/RpcServer/config.json
@@ -10,6 +10,8 @@
         "TrustedAuthorities": [],
         "RpcUser": "",
         "RpcPass": "",
+        "EnableCors": false,
+        "AllowOrigins": [],
         "MaxGasInvoke": 20,
         "MaxFee": 0.1,
         "MaxConcurrentConnections": 40,


### PR DESCRIPTION
closes #811 

**Change Log**
- Fixed basic auth to work now, and popup auth window in browser
- Fixed CORS with basic auth
- Added AllowOrigins for basic auth to work