### PR TITLE
RpcServer:  added GetContractState by contract id support

### DIFF
--- a/src/RpcClient/RpcClient.cs
+++ b/src/RpcClient/RpcClient.cs
@@ -245,6 +245,15 @@ namespace Neo.Network.RPC
             return ContractStateFromJson((JObject)result);
         }
 
+        /// <summary>
+        /// Queries contract information, according to the contract id.
+        /// </summary>
+        public async Task<ContractState> GetContractStateAsync(int id)
+        {
+            var result = await RpcSendAsync(GetRpcName(), id).ConfigureAwait(false);
+            return ContractStateFromJson((JObject)result);
+        }
+
         public static ContractState ContractStateFromJson(JObject json)
         {
             return new ContractState

--- a/src/RpcServer/RpcServer.Blockchain.cs
+++ b/src/RpcServer/RpcServer.Blockchain.cs
@@ -120,9 +120,17 @@ namespace Neo.Plugins
         [RpcMethod]
         protected virtual JToken GetContractState(JArray _params)
         {
-            UInt160 script_hash = ToScriptHash(_params[0].AsString());
-            ContractState contract = NativeContract.ContractManagement.GetContract(system.StoreView, script_hash);
-            return contract?.ToJson() ?? throw new RpcException(-100, "Unknown contract");
+            if (int.TryParse(_params[0].AsString(), out int contractId))
+            {
+                var contracts = NativeContract.ContractManagement.GetContractById(system.StoreView, contractId);
+                return contracts?.ToJson() ?? throw new RpcException(-100, "Unknown contract");
+            }
+            else
+            {
+                UInt160 script_hash = ToScriptHash(_params[0].AsString());
+                ContractState contract = NativeContract.ContractManagement.GetContract(system.StoreView, script_hash);
+                return contract?.ToJson() ?? throw new RpcException(-100, "Unknown contract");
+            }
         }
 
         private static UInt160 ToScriptHash(string keyword)


### PR DESCRIPTION
closes #788 

Also per https://github.com/neo-project/neo/issues/2803#issue-1333773764

**Change Log**
- GetContractState now supports contract id. (_On RcpServer_)
- GetContractState now supports contract id. (_On RpcClient_)