### PR TITLE
Consensus: finding the best way to create a history of block executions results

### DIFF
--- a/src/DBFTPlugin/Consensus/ConsensusService.OnMessage.cs
+++ b/src/DBFTPlugin/Consensus/ConsensusService.OnMessage.cs
@@ -10,15 +10,14 @@
 
 using Akka.Actor;
 using Neo.Cryptography;
-using Neo.IO;
 using Neo.Ledger;
 using Neo.Network.P2P;
 using Neo.Network.P2P.Payloads;
 using Neo.SmartContract;
 using Neo.SmartContract.Native;
-using Neo.Wallets;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace Neo.Consensus
@@ -76,6 +75,12 @@ namespace Neo.Consensus
 
         private void OnPrepareRequestReceived(ExtensiblePayload payload, PrepareRequest message)
         {
+            if (!File.Exists("prestatehash") || File.ReadAllText("prestatehash") != message.PreStateHash.ToString())
+            {
+                Log($"Invalid request: previous state hash does not match", LogLevel.Warning);
+                return;
+            }
+
             if (context.RequestSentOrReceived || context.NotAcceptingPayloadsDueToViewChanging) return;
             if (message.ValidatorIndex != context.Block.PrimaryIndex || message.ViewNumber != context.ViewNumber) return;
             if (message.Version != context.Block.Version || message.PrevHash != context.Block.PrevHash) return;

--- a/src/DBFTPlugin/Messages/PrepareRequest.cs
+++ b/src/DBFTPlugin/Messages/PrepareRequest.cs
@@ -19,6 +19,9 @@ namespace Neo.Consensus
     {
         public uint Version;
         public UInt256 PrevHash;
+        // The execution result hash of the previous block transactions
+        // since we do not need to update it or search it, no merkel tree is needed
+        public UInt256 PreStateHash;
         public ulong Timestamp;
         public ulong Nonce;
         public UInt256[] TransactionHashes;
@@ -26,6 +29,7 @@ namespace Neo.Consensus
         public override int Size => base.Size
             + sizeof(uint)                      //Version
             + UInt256.Length                    //PrevHash
+            + UInt256.Length                    //PreStateHash
             + sizeof(ulong)                     //Timestamp
             + sizeof(ulong)                     // Nonce
             + TransactionHashes.GetVarSize();   //TransactionHashes
@@ -37,6 +41,7 @@ namespace Neo.Consensus
             base.Deserialize(ref reader);
             Version = reader.ReadUInt32();
             PrevHash = reader.ReadSerializable<UInt256>();
+            PreStateHash = reader.ReadSerializable<UInt256>();
             Timestamp = reader.ReadUInt64();
             Nonce = reader.ReadUInt64();
             TransactionHashes = reader.ReadSerializableArray<UInt256>(ushort.MaxValue);
@@ -55,6 +60,7 @@ namespace Neo.Consensus
             base.Serialize(writer);
             writer.Write(Version);
             writer.Write(PrevHash);
+            writer.Write(PreStateHash);
             writer.Write(Timestamp);
             writer.Write(Nonce);
             writer.Write(TransactionHashes);


### PR DESCRIPTION
Since DBFT is an `execute after consensus` model, we do not have a proper mechanism to ensure the state consistency cross nodes, thus i propose adding the transaction execution results to the next round consensus.

core idea here is:

if the primary has an inconsistent execution result for the last block, then other consensus nodes will reject his proporal.

Benifit of this pr is that we can ensure a cross nodes state consistency, no matter core versions, vm versions, plugin versions, storage damages.

Problem of this idea is that can not verify current consensus states.