### PR TITLE
RpcServer, RpcClient: strip HF_ prefix from `getversion` response

### DIFF
--- a/src/RpcClient/Models/RpcVersion.cs
+++ b/src/RpcClient/Models/RpcVersion.cs
@@ -44,7 +44,8 @@ namespace Neo.Network.RPC.Models
                 json["initialgasdistribution"] = InitialGasDistribution;
                 json["hardforks"] = new JArray(Hardforks.Select(s => new JObject()
                 {
-                    ["name"] = s.Key,
+                    // Strip HF_ prefix.
+                    ["name"] = s.Key.ToString().Substring(3),
                     ["blockheight"] = s.Value,
                 }));
                 return json;
@@ -63,7 +64,7 @@ namespace Neo.Network.RPC.Models
                     MaxTransactionsPerBlock = (uint)json["maxtransactionsperblock"].AsNumber(),
                     MemoryPoolMaxTransactions = (int)json["memorypoolmaxtransactions"].AsNumber(),
                     InitialGasDistribution = (ulong)json["initialgasdistribution"].AsNumber(),
-                    Hardforks = new Dictionary<Hardfork, uint>(((JArray)json["hardforks"]).Select(s => new KeyValuePair<Hardfork, uint>(Enum.Parse<Hardfork>(s["name"].AsString()), (uint)s["blockheight"].AsNumber()))),
+                    Hardforks = new Dictionary<Hardfork, uint>(((JArray)json["hardforks"]).Select(s => new KeyValuePair<Hardfork, uint>(Enum.Parse<Hardfork>($"HF_{s["name"].AsString()}"), (uint)s["blockheight"].AsNumber()))),
                 };
             }
         }

--- a/src/RpcClient/Models/RpcVersion.cs
+++ b/src/RpcClient/Models/RpcVersion.cs
@@ -45,7 +45,7 @@ namespace Neo.Network.RPC.Models
                 json["hardforks"] = new JArray(Hardforks.Select(s => new JObject()
                 {
                     // Strip HF_ prefix.
-                    ["name"] = s.Key.ToString().Substring(3),
+                    ["name"] = StripPrefix(s.Key.ToString(), "HF_"),
                     ["blockheight"] = s.Value,
                 }));
                 return json;
@@ -64,8 +64,18 @@ namespace Neo.Network.RPC.Models
                     MaxTransactionsPerBlock = (uint)json["maxtransactionsperblock"].AsNumber(),
                     MemoryPoolMaxTransactions = (int)json["memorypoolmaxtransactions"].AsNumber(),
                     InitialGasDistribution = (ulong)json["initialgasdistribution"].AsNumber(),
-                    Hardforks = new Dictionary<Hardfork, uint>(((JArray)json["hardforks"]).Select(s => new KeyValuePair<Hardfork, uint>(Enum.Parse<Hardfork>($"HF_{s["name"].AsString()}"), (uint)s["blockheight"].AsNumber()))),
+                    Hardforks = new Dictionary<Hardfork, uint>(((JArray)json["hardforks"]).Select(s =>
+                    {
+                        var name = s["name"].AsString();
+                        // Add HF_ prefix to the hardfork response for proper Hardfork enum parsing.
+                        return new KeyValuePair<Hardfork, uint>(Enum.Parse<Hardfork>(name.StartsWith("HF_") ? name : $"HF_{name}"), (uint)s["blockheight"].AsNumber());
+                    })),
                 };
+            }
+
+            private static string StripPrefix(string s, string prefix)
+            {
+                return s.StartsWith(prefix) ? s.Substring(prefix.Length) : s;
             }
         }
 

--- a/src/RpcServer/RpcServer.Node.cs
+++ b/src/RpcServer/RpcServer.Node.cs
@@ -86,11 +86,16 @@ namespace Neo.Plugins
             {
                 JObject forkJson = new();
                 // Strip "HF_" prefix.
-                forkJson["name"] = hf.Key.ToString().Substring(3);
+                forkJson["name"] = StripPrefix(hf.Key.ToString(), "HF_");
                 forkJson["blockheight"] = hf.Value;
                 return forkJson;
             }));
             return json;
+        }
+
+        private static string StripPrefix(string s, string prefix)
+        {
+            return s.StartsWith(prefix) ? s.Substring(prefix.Length) : s;
         }
 
         [RpcMethod]

--- a/src/RpcServer/RpcServer.Node.cs
+++ b/src/RpcServer/RpcServer.Node.cs
@@ -85,7 +85,8 @@ namespace Neo.Plugins
             json["protocol"]["hardforks"] = new JArray(system.Settings.Hardforks.Select(hf =>
             {
                 JObject forkJson = new();
-                forkJson["name"] = hf.Key;
+                // Strip "HF_" prefix.
+                forkJson["name"] = hf.Key.ToString().Substring(3);
                 forkJson["blockheight"] = hf.Value;
                 return forkJson;
             }));

--- a/tests/Neo.Network.RPC.Tests/RpcTestCases.json
+++ b/tests/Neo.Network.RPC.Tests/RpcTestCases.json
@@ -2494,7 +2494,7 @@
           "initialgasdistribution": 0,
           "hardforks": [
             {
-              "name": "HF_Aspidochelone",
+              "name": "Aspidochelone",
               "blockheight": 0
             }
           ]


### PR DESCRIPTION
It's nice to have clear hardfork ame without hardfork prefix so that the resulting hardfork JSON-ized name can be applicable by both C# and NeoGo nodes.

Ref. https://github.com/neo-project/neo-modules/issues/822.