### PR TITLE
Add debug mode to the applicationlog to get log info

### DIFF
--- a/src/ApplicationLogs/LogReader.cs
+++ b/src/ApplicationLogs/LogReader.cs
@@ -214,9 +214,11 @@ namespace Neo.Plugins
             {
                 logList = (JArray)JToken.Parse(Neo.Utility.StrictUTF8.GetString(value));
             }
-            var logJson = new JObject();
-            logJson["contract"] = args.ScriptHash.ToString();
-            logJson["message"] = args.Message;
+            var logJson = new JObject
+            {
+                ["contract"] = args.ScriptHash.ToString(),
+                ["message"] = args.Message
+            };
             logList?.Add(logJson);
 
             _snapshot.Put(LogPrefix.Concat(tx.ToArray()).ToArray(), Neo.Utility.StrictUTF8.GetBytes(logList?.ToString()!));

--- a/src/ApplicationLogs/Settings.cs
+++ b/src/ApplicationLogs/Settings.cs
@@ -18,6 +18,8 @@ namespace Neo.Plugins
         public uint Network { get; }
         public int MaxStackSize { get; }
 
+        public bool Debug { get; }
+
         public static Settings Default { get; private set; }
 
         private Settings(IConfigurationSection section)
@@ -25,6 +27,7 @@ namespace Neo.Plugins
             this.Path = section.GetValue("Path", "ApplicationLogs_{0}");
             this.Network = section.GetValue("Network", 5195086u);
             this.MaxStackSize = section.GetValue("MaxStackSize", (int)ushort.MaxValue);
+            this.Debug = section.GetValue("Debug", false);
         }
 
         public static void Load(IConfigurationSection section)

--- a/src/ApplicationLogs/config.json
+++ b/src/ApplicationLogs/config.json
@@ -2,7 +2,8 @@
   "PluginConfiguration": {
     "Path": "ApplicationLogs_{0}",
     "Network": 860833102,
-    "MaxStackSize": 65535
+    "MaxStackSize": 65535,
+    "Debug": false
   },
   "Dependency": [
     "RpcServer"

--- a/src/RpcClient/Models/RpcApplicationLog.cs
+++ b/src/RpcClient/Models/RpcApplicationLog.cs
@@ -72,7 +72,11 @@ namespace Neo.Network.RPC.Models
             json["exception"] = ExceptionMessage;
             json["stack"] = Stack.Select(q => q.ToJson()).ToArray();
             json["notifications"] = Notifications.Select(q => q.ToJson()).ToArray();
-            json["logs"] = Logs?.Select(q => q.ToJson()).ToArray();
+            // Only add "logs" to json if Logs is not null
+            if (Logs != null)
+            {
+                json["logs"] = Logs.Select(q => q.ToJson()).ToArray();
+            }
             return json;
         }
 

--- a/src/RpcClient/Models/RpcApplicationLog.cs
+++ b/src/RpcClient/Models/RpcApplicationLog.cs
@@ -61,6 +61,8 @@ namespace Neo.Network.RPC.Models
 
         public List<RpcNotifyEventArgs> Notifications { get; set; }
 
+        public List<RpcLogEventArgs> Logs { get; set; }
+
         public JObject ToJson()
         {
             JObject json = new();
@@ -70,6 +72,7 @@ namespace Neo.Network.RPC.Models
             json["exception"] = ExceptionMessage;
             json["stack"] = Stack.Select(q => q.ToJson()).ToArray();
             json["notifications"] = Notifications.Select(q => q.ToJson()).ToArray();
+            json["logs"] = Logs?.Select(q => q.ToJson()).ToArray();
             return json;
         }
 
@@ -82,7 +85,8 @@ namespace Neo.Network.RPC.Models
                 GasConsumed = long.Parse(json["gasconsumed"].AsString()),
                 ExceptionMessage = json["exception"]?.AsString(),
                 Stack = ((JArray)json["stack"]).Select(p => Utility.StackItemFromJson((JObject)p)).ToList(),
-                Notifications = ((JArray)json["notifications"]).Select(p => RpcNotifyEventArgs.FromJson((JObject)p, protocolSettings)).ToList()
+                Notifications = ((JArray)json["notifications"]).Select(p => RpcNotifyEventArgs.FromJson((JObject)p, protocolSettings)).ToList(),
+                Logs = ((JArray)json["logs"])?.Select(p => RpcLogEventArgs.FromJson((JObject)p, protocolSettings)).ToList()
             };
         }
     }
@@ -111,6 +115,31 @@ namespace Neo.Network.RPC.Models
                 Contract = json["contract"].ToScriptHash(protocolSettings),
                 EventName = json["eventname"].AsString(),
                 State = Utility.StackItemFromJson((JObject)json["state"])
+            };
+        }
+    }
+
+    public class RpcLogEventArgs
+    {
+        public UInt160 Contract { get; set; }
+
+        public string Message { get; set; }
+
+        public JObject ToJson()
+        {
+            return new JObject
+            {
+                ["contract"] = Contract.ToString(),
+                ["message"] = Message
+            };
+        }
+
+        public static RpcLogEventArgs FromJson(JObject json, ProtocolSettings protocolSettings)
+        {
+            return new RpcLogEventArgs
+            {
+                Contract = json["contract"].ToScriptHash(protocolSettings),
+                Message = json["message"]?.AsString(),
             };
         }
     }


### PR DESCRIPTION
Closes #841 

This pr focus on adding a debug mode to the applicationlog plugin such that developers can get the transaction execution log via the rpc interface.

What has changed?

- The config adds a debug field.
- Added Log monitor logic.
- Logs field will be added to the json response under debug mode.
- Update the rpcclient to support logs in response.

Will this impact other tools?

No
