### PR TITLE
Added AspNetCore to `RPCServer`

### DIFF
--- a/src/RpcServer/RpcServer.csproj
+++ b/src/RpcServer/RpcServer.csproj
@@ -4,4 +4,7 @@
     <PackageId>Neo.Plugins.RpcServer</PackageId>
   </PropertyGroup>
 
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
After removing `AspNetCore` from `NeoCore`, this needs to be added now.